### PR TITLE
Improve error alerts

### DIFF
--- a/base/components/MessageBar.jsx
+++ b/base/components/MessageBar.jsx
@@ -47,7 +47,7 @@ const MessageBarItem = ({message}) => {
 		<div className={alertType}>
 			{text}
 			{Messaging.jsxFromId[message.id]}
-			<div className="hidden">Details {message.details}</div>
+			{ message.details ? <div className="hidden">Details {message.details}</div> : <></> }
 			<CloseButton onClick={ e => { message.closed=true; DataStore.update(); } } />
 		</div>
 	);

--- a/base/plumbing/ServerIOBase.js
+++ b/base/plumbing/ServerIOBase.js
@@ -447,9 +447,12 @@ ServerIO.load = function(url, params) {
 			let text = response.status===404? 
 				"404: Sadly that content could not be found."
 				: "Could not load "+params.url+" from the server";
-			if (response.responseText && ! (response.status >= 500)) {
-				// NB: dont show the nginx error page for a 500 server fail
+			if (response.responseText && response.status <= 500) {
 				text = response.responseText;
+			}
+			if (response.statusText && response.status > 500) {
+				// Nginx sets responseText to HTML pages for these, so instead just use statusText (eg 'Bad Gateway').
+				text = response.statusText;
 			}
 			let msg = {
 				id: 'error from '+params.url,


### PR DESCRIPTION
before this, 

- if you forgot to start the SoGive server locally & went to http://local.sogive.org/#search, you'd see:
![before_couldnotload-search](https://user-images.githubusercontent.com/1918555/108120055-9a3d9880-7098-11eb-9170-d331b4a5c146.png)
- and if instead the server is running but Elastic Search stops running, you'd see the same thing.

Now,
- if you forget to start the server you see this:
![after-bad_gateway](https://user-images.githubusercontent.com/1918555/108120352-0d470f00-7099-11eb-867d-18beb63cb995.png)

- and if your Elastic Search instance goes down, you see this:
![after-es_down](https://user-images.githubusercontent.com/1918555/108120600-72026980-7099-11eb-8aae-e907ea5188a6.png)

- Also, if you enter a malformed url at http://local.sogive.org/#editordashboard you now see this:
![after_import](https://user-images.githubusercontent.com/1918555/108119939-6b272700-7098-11eb-9b5e-d0234ad5d887.png)
(instead of "Could not load /import.json from the server \nDetails")