### PR TITLE
Support light-themed navbar

### DIFF
--- a/base/components/MainDivBase.jsx
+++ b/base/components/MainDivBase.jsx
@@ -71,6 +71,8 @@ const init = () => {
 	props:
 	pageForPath: {String:JSX}
 	navbarPages: String[]|() => String[]
+	navbarDarkTheme: {?boolean}
+	navbarBackgroundColour: {?String}
 	loginRequired: {?boolean}
 	securityCheck: ({page}) => throw error / return true
 	SecurityFailPage: ?JSX
@@ -102,6 +104,8 @@ class MainDivBase extends Component {
 			loginRequired,
 			defaultPage,
 			navbar=true, // false for no navbar!
+			navbarDarkTheme=true,
+			navbarBackgroundColour="dark",
 			fullWidthPages,
 			noRegister,			
 		} = this.props;
@@ -153,7 +157,7 @@ class MainDivBase extends Component {
 		//
 		return (
 			<div>
-				{navbar? <NavBar page={page} pages={navbarPages} labels={navbarLabels} ></NavBar> : null}
+				{navbar? <NavBar page={page} pages={navbarPages} labels={navbarLabels} darkTheme={navbarDarkTheme} backgroundColour={navbarBackgroundColour} ></NavBar> : null}
 				<Container fluid={fluid} >
 					<MessageBar />
 					<div className="page" id={page}>

--- a/base/components/NavBar.jsx
+++ b/base/components/NavBar.jsx
@@ -48,6 +48,8 @@ const DefaultNavGuts = ({pageLinks, currentPage, children, homelink, isOpen, tog
  * @param {?String} homelink Relative url for the home-page. Defaults to "/"
  * @param {String[]} pages
  * @param {?String[]|Function|Object} labels Map options to nice strings.
+ * @param {?boolean} darkTheme Whether to style navbar links for a dark theme (use with a dark backgroundColour)
+ * @param {?String} backgroundColour Background colour for the nav bar.
  */
 const NavBar = ({NavGuts = DefaultNavGuts, ...props}) => {
 	// see setNavProps()
@@ -55,7 +57,7 @@ const NavBar = ({NavGuts = DefaultNavGuts, ...props}) => {
 	if (dsProps) {
 		props = Object.assign({}, props, dsProps);
 	}
-	let {currentPage, pages, labels} = props; // ??This de-ref, and the pass-down of props to NavGuts feels clumsy/opaque
+	let {currentPage, pages, labels, darkTheme, backgroundColour} = props; // ??This de-ref, and the pass-down of props to NavGuts feels clumsy/opaque
 	const labelFn = labeller(pages, labels);
 
 	// Handle nav toggling
@@ -79,7 +81,7 @@ const NavBar = ({NavGuts = DefaultNavGuts, ...props}) => {
 	));
 
 	return (
-		<Navbar sticky="top" dark color="dark" expand="md" className='p-1'>
+		<Navbar sticky="top" dark={darkTheme} color={backgroundColour} expand="md" className='p-1'>
 			<NavGuts {...props} pageLinks={pageLinks} isOpen={isOpen} toggle={toggle} />
 		</Navbar>
 	);


### PR DESCRIPTION
- Refactor to make existing Navbar `dark` and `color` attributes
  optional parameters of MainDivBase.

- This is a no-op for existing clients since it defaults to current
  values (`true` and `dark`), but will allow SoGive to switch to a light
  theme by setting the parameters to `false` and `white`.