### PR TITLE
Support external navbar links

### DIFF
--- a/base/components/MainDivBase.jsx
+++ b/base/components/MainDivBase.jsx
@@ -71,6 +71,7 @@ const init = () => {
 	props:
 	pageForPath: {String:JSX}
 	navbarPages: String[]|() => String[]
+	navbarExternalLinks: {?Object}
 	navbarDarkTheme: {?boolean}
 	navbarBackgroundColour: {?String}
 	loginRequired: {?boolean}
@@ -99,7 +100,7 @@ class MainDivBase extends Component {
 		init();
 		let {
 			pageForPath, 
-			navbarPages, navbarLabels, navbarChildren,
+			navbarPages, navbarLabels, navbarChildren, navbarExternalLinks,
 			securityCheck, SecurityFailPage=DefaultErrorPage, 
 			loginRequired,
 			defaultPage,
@@ -156,17 +157,30 @@ class MainDivBase extends Component {
 		let fluid = (fullWidthPages && fullWidthPages.includes(page)) || window.fullWidthPage;
 		//
 		return (
-			<div>
-				{navbar? <NavBar page={page} pages={navbarPages} labels={navbarLabels} darkTheme={navbarDarkTheme} backgroundColour={navbarBackgroundColour} ></NavBar> : null}
-				<Container fluid={fluid} >
-					<MessageBar />
-					<div className="page" id={page}>
-						<Page />
-					</div>
-				</Container>
-				<LoginWidget title={`Welcome to ${C.app.name}`} noRegister={noRegister} services={noRegister ? [] : undefined}/>
-			</div>
-		);
+      <div>
+        {navbar ? (
+          <NavBar
+            page={page}
+            pages={navbarPages}
+            labels={navbarLabels}
+            externalLinks={navbarExternalLinks}
+            darkTheme={navbarDarkTheme}
+            backgroundColour={navbarBackgroundColour}
+          ></NavBar>
+        ) : null}
+        <Container fluid={fluid}>
+          <MessageBar />
+          <div className="page" id={page}>
+            <Page />
+          </div>
+        </Container>
+        <LoginWidget
+          title={`Welcome to ${C.app.name}`}
+          noRegister={noRegister}
+          services={noRegister ? [] : undefined}
+        />
+      </div>
+    );
 	} // ./render()
 } // ./MainDiv
 

--- a/base/components/MainDivBase.jsx
+++ b/base/components/MainDivBase.jsx
@@ -69,6 +69,8 @@ const init = () => {
 	So the props will remain fixed.
 
 	props:
+
+	homelink: {String} - Relative url for the home-page. Defaults to "/"
 	pageForPath: {String:JSX}
 	navbarPages: String[]|() => String[]
 	navbarExternalLinks: {?Object}
@@ -99,6 +101,7 @@ class MainDivBase extends Component {
 	render() {
 		init();
 		let {
+			homeLink,
 			pageForPath, 
 			navbarPages, navbarLabels, navbarChildren, navbarExternalLinks,
 			securityCheck, SecurityFailPage=DefaultErrorPage, 
@@ -164,6 +167,7 @@ class MainDivBase extends Component {
             pages={navbarPages}
             labels={navbarLabels}
             externalLinks={navbarExternalLinks}
+			homelink={homeLink}
             darkTheme={navbarDarkTheme}
             backgroundColour={navbarBackgroundColour}
           ></NavBar>

--- a/base/components/NavBar.jsx
+++ b/base/components/NavBar.jsx
@@ -47,6 +47,7 @@ const DefaultNavGuts = ({pageLinks, currentPage, children, homelink, isOpen, tog
  * @param {?String} currentPage e.g. 'account' Read from window.location via DataStore if unset.
  * @param {?String} homelink Relative url for the home-page. Defaults to "/"
  * @param {String[]} pages
+ * @param {?Object} externalLinks Map page names to external links.
  * @param {?String[]|Function|Object} labels Map options to nice strings.
  * @param {?boolean} darkTheme Whether to style navbar links for a dark theme (use with a dark backgroundColour)
  * @param {?String} backgroundColour Background colour for the nav bar.
@@ -57,7 +58,7 @@ const NavBar = ({NavGuts = DefaultNavGuts, ...props}) => {
 	if (dsProps) {
 		props = Object.assign({}, props, dsProps);
 	}
-	let {currentPage, pages, labels, darkTheme, backgroundColour} = props; // ??This de-ref, and the pass-down of props to NavGuts feels clumsy/opaque
+	let {currentPage, pages, labels, externalLinks, darkTheme, backgroundColour} = props; // ??This de-ref, and the pass-down of props to NavGuts feels clumsy/opaque
 	const labelFn = labeller(pages, labels);
 
 	// Handle nav toggling
@@ -72,13 +73,15 @@ const NavBar = ({NavGuts = DefaultNavGuts, ...props}) => {
 	}
 	
 	// make the page links
-	const pageLinks = pages.map(page => (
-		<NavItem key={`navitem_${page}`} active={page === currentPage}>
-			<NavLink href={`#${page}`} onClick={close} >
+	const pageLinks = pages.map(page => {
+		let pageLink = `#${page}`;
+		if (externalLinks && page in externalLinks) pageLink = externalLinks[page];
+		return( <NavItem key={`navitem_${page}`} active={page === currentPage}>
+			<NavLink href={pageLink} onClick={close} >
 				{labelFn(page)}
 			</NavLink>
-		</NavItem>
-	));
+		</NavItem>)
+	});
 
 	return (
 		<Navbar sticky="top" dark={darkTheme} color={backgroundColour} expand="md" className='p-1'>


### PR DESCRIPTION
Required for new SoGive top navbar links (Home, About, Contact, FAQ) to link back to sogive.org links

Also support passing in a 'homeLink' prop to override where the logo in the navbar links to.

Paired with @aissshah on this