### PR TITLE
Set Navbar light property when darkTheme is false

### DIFF
--- a/base/components/NavBar.jsx
+++ b/base/components/NavBar.jsx
@@ -119,7 +119,7 @@ const NavBar = ({NavGuts = DefaultNavGuts, ...props}) => {
 	});
 
 	return (
-		<Navbar sticky="top" dark={darkTheme} color={backgroundColour} expand="md" className='p-1'>
+		<Navbar sticky="top" dark={darkTheme} light={!darkTheme} color={backgroundColour} expand="md" className='p-1'>
 			<NavGuts {...props} pageLinks={pageLinks} isOpen={isOpen} toggle={toggle} />
 		</Navbar>
 	);


### PR DESCRIPTION
Turns out you need to explicitly set `light=true` in the reactstrap Navbar component to get light styling. 

Not noticeable on desktop, but on mobile the menu button background image won't be set unless the style is navbar-light, making the button invisible.

In SoGive, Before this change:
![before-navbar-mobile](https://user-images.githubusercontent.com/1918555/126063886-9ff9c1a8-041c-4878-8381-994aa6788589.png)


After this change:
![after-navbar-mobile](https://user-images.githubusercontent.com/1918555/126063888-2e20e56e-da09-474a-80fa-bdac5956da42.png)


