### PR TITLE
Fix support for navbar child components in MainDivBase

### DIFF
--- a/base/components/MainDivBase.jsx
+++ b/base/components/MainDivBase.jsx
@@ -73,6 +73,7 @@ const init = () => {
 	homelink: {String} - Relative url for the home-page. Defaults to "/"
 	pageForPath: {String:JSX}
 	navbarPages: String[]|() => String[]
+	navbarChildren: ?JSX
 	navbarExternalLinks: {?Object}
 	navbarDarkTheme: {?boolean}
 	navbarBackgroundColour: {?String}
@@ -170,6 +171,7 @@ class MainDivBase extends Component {
 			homelink={homeLink}
             darkTheme={navbarDarkTheme}
             backgroundColour={navbarBackgroundColour}
+            children={navbarChildren}
           ></NavBar>
         ) : null}
         <Container fluid={fluid}>


### PR DESCRIPTION
- Note that NavProps already included `children`, DefaultNavGuts rendered them, and `navbarChildren` was already unwrapped from MainDivBase props - but unused. This change fixes that by passing `navbarChildren` as the NavBar `children` property.

- Motivation for fixing this is to allow SoGive code to include a search widget in the NavBar (I will send a PR to sogive-app to start using navbarChildren today).
