### PR TITLE
Feature/2022 08/green tag bulk upload

### DIFF
--- a/base/components/PropControls/PropControlUpload.jsx
+++ b/base/components/PropControls/PropControlUpload.jsx
@@ -9,6 +9,7 @@ import Misc from '../Misc';
 import { urlValidator } from './validators';
 import Icon from '../Icon';
 import LinkOut from '../LinkOut';
+import { space } from '../../utils/miscutils';
 
 
 /** MIME type sets */
@@ -199,7 +200,7 @@ const PropControlUpload = ({ path, prop, onUpload, type, bg, storeValue, value, 
 	};
 
 	// New hooks-based DropZone - give it your upload specs & an upload-accepting function, receive props-generating functions
-	const { getRootProps, getInputProps } = useDropzone({accept: acceptTypes[type], onDrop});
+	const { getRootProps, getInputProps } = useDropzone({accept: acceptTypes[type], onDrop, disabled: otherStuff.disabled});
 
 	// Catch special background-colour name for img and apply a special background to show img transparency
 	let className;
@@ -261,7 +262,7 @@ const PropControlUpload = ({ path, prop, onUpload, type, bg, storeValue, value, 
 			{collapse && <Button className="pull-left" title="upload media" onClick={e => setCollapsed( ! collapsed)} color="secondary" size={size}><Icon color="white" name="outtray" /></Button>}
 			{isOpen && <>
 				<FormControl type="url" name={prop} value={storeValue} onChange={onChange} {...otherStuff} />
-				<div className="DropZone pull-left my-1 p-1" {...getRootProps()}>
+				<div className={space('DropZone pull-left my-1 p-1', otherStuff.disabled && 'disabled')} {...getRootProps()}>
 					<input {...getInputProps()} />
 					Drop a {acceptDescs[type]} here
 				</div>
@@ -276,7 +277,7 @@ const PropControlUpload = ({ path, prop, onUpload, type, bg, storeValue, value, 
 				</div>
 			}
 			{extraControls}
-			<div className="clearfix" />			
+			<div className="clearfix" />
 		</div>
 	);
 }; // ./imgUpload

--- a/base/components/PropControls/PropControlUpload.jsx
+++ b/base/components/PropControls/PropControlUpload.jsx
@@ -143,7 +143,7 @@ const FontThumbnail = ({url}) => {
  * @param {?Boolean} cacheControls Show "don't use mediacache to resize, always load full-size" hash-wart checkbox
  * @param {?Boolean} circleCrop Show "crop to X% when displayed in a circle" hash-wart control
  */
-const PropControlUpload = ({ path, prop, onUpload, type, bg, storeValue, value, onChange, collapse, size, version="raw", cacheControls, circleCrop, ...otherStuff }) => {
+const PropControlUpload = ({ path, prop, onUpload, type, bg, storeValue, value, onChange, collapse, size, version="raw", cacheControls, circleCrop, endpoint, uploadParams, ...otherStuff }) => {
 	delete otherStuff.https;
 
 	const [collapsed, setCollapsed] = useState(true);
@@ -169,7 +169,11 @@ const PropControlUpload = ({ path, prop, onUpload, type, bg, storeValue, value, 
 		const load = () => setUploading(false);
 
 		accepted.forEach(file => {
-			ServerIO.upload(file, progress, load)
+			const uploadOptions = {};
+			if (uploadParams) uploadOptions.params = uploadParams;
+			if (endpoint) uploadOptions.endpoint = endpoint;
+
+			ServerIO.upload(file, progress, load, uploadOptions)
 				.done(response => {
 					// TODO refactor to clean this up -- we should have one way of doing things.
 					// Different forms for UploadServlet vs MediaUploadServlet
@@ -186,7 +190,7 @@ const PropControlUpload = ({ path, prop, onUpload, type, bg, storeValue, value, 
 				})
 				.fail(res => res.status == 413 && notifyUser(new Error(res.statusText)));
 				// Record start time of current upload
-				setUploading({start: new Date().getTime()}); 
+				setUploading({start: new Date().getTime()});
 		});
 		rejected.forEach(file => {
 			// TODO Inform the user that their file had a Problem

--- a/base/plumbing/ServerIOBase.js
+++ b/base/plumbing/ServerIOBase.js
@@ -215,7 +215,7 @@ if (C.isProduction()) {
 }
 
 
-ServerIO.upload = function(file, progress, load) {
+ServerIO.upload = function(file, progress, load, {params, endpoint = ServerIO.MEDIA_ENDPOINT}) {
 	// Provide a pre-constructed XHR so we can insert progress/load callbacks
 	const makeXHR = () => {
 		const xhr = $.ajaxSettings.xhr(); //new window.XMLHttpRequest();
@@ -230,8 +230,9 @@ ServerIO.upload = function(file, progress, load) {
 
 	const data = new FormData(); // This is a browser native thing: https://developer.mozilla.org/en-US/docs/Web/API/FormData
 	data.append('upload', file);
+	params && Object.entries(params).forEach(([k, v]) => data.append(k, v));
 
-	return ServerIO.load(ServerIO.MEDIA_ENDPOINT, {
+	return ServerIO.load(endpoint, {
 		xhr: makeXHR,
 		data,
 		type: 'POST',
@@ -240,7 +241,6 @@ ServerIO.upload = function(file, progress, load) {
 		swallow: true,
 	});
 };
-
 
 
 /**

--- a/base/style/Misc.less
+++ b/base/style/Misc.less
@@ -11,6 +11,9 @@
 	border-radius: 5px;
 	cursor: pointer;
 	// font-weight: bold; why?
+	&.disabled {
+		border-color: #aaa;
+	}
 }
 
 /* have the save button always visible */


### PR DESCRIPTION
Needed by the matching branch in adserver. Adds some versatility to PropControlUpload for use in the green tag bulk uploader - allows overriding the endpoint & adding companion data (in this case, a template tag to merge with the CSV rows) on uploads.