### PR TITLE
add CSV export button to chartwidget

### DIFF
--- a/base/components/ChartWidget.jsx
+++ b/base/components/ChartWidget.jsx
@@ -100,8 +100,25 @@ class ChartWidget extends React.Component {
 					<div>
 						{true ? <small>Labels: {JSON.stringify(keys)}, Total data points: {dataPoints}</small> : null}
 					</div>
+					{ dataPoints ? <a href="#" onClick={(e) => { e.preventDefault(); this.exportCSV(chartData); }}>&#128229; Download .csv</a> : null }	
 				</div>);
 	} // ./render
+
+	exportCSV(chartData) {
+		let rows = [
+			["event", "date", "count"]
+		];
+
+		Object.values(chartData.datasets).forEach(dataset => {
+			Object.values(dataset.data).forEach(datapoint => {
+				rows.push([dataset.label, datapoint.x, datapoint.y]);
+			})
+		});
+
+		let csvData = "data:text/csv;charset=utf-8," + rows.map(e => e.join(",")).join("\n");
+
+		window.open(encodeURI(csvData));
+	} // ./exportCSV
 } 
 
 /**


### PR DESCRIPTION
Hello,

This will add a "Download .csv" button beneath the widget shown in the "events over time" tab in the Portal dashboard reports section.

Can be seen here: https://localportal.good-loop.com/#dashboard?bby=vert&q=5BMfAc1OyI&start=2022-08-15&end=2022-08-25&server=production
