### PR TITLE
bug/2022-09/save-as-switches

### DIFF
--- a/base/plumbing/Crud.js
+++ b/base/plumbing/Crud.js
@@ -269,10 +269,11 @@ ActionMan.saveEdits = saveEdits;
  * AKA copy!
  * 
  * This will modify the ID to a new nonce()!
- * @param {?String} id DEPRECATED use oldId
- * @param {!String} oldId The item which is being copied
- * @param onChange {Function: newItem => ()}
- * @returns PromiseValue(DataItem)
+ * @param {Object} p
+ * @param {?String} p.id DEPRECATED use oldId
+ * @param {!String} p.oldId The item which is being copied
+ * @param {?Function} p.onChange {Function: newItem => ()} Use this to e.g. change the url
+ * @returns PromiseValue(DataItem) 
  */
  const saveAs = ({type, id, oldId, item, onChange}) => {
 	oldId = id = (oldId || id); // bridge to old code

--- a/base/plumbing/glrouter.jsx
+++ b/base/plumbing/glrouter.jsx
@@ -6,14 +6,25 @@ import React, { Component } from 'react';
 import { encURI, mapkv, modifyHash, stopEvent, yessy } from '../utils/miscutils';
 import DataStore from './DataStore';
 
-const goto = href => {
+/**
+ * Navigate without a page reload. Also scrolls to the page top
+ * @param {?string} href 
+ * @param {?Object} options
+ * @param {?boolean} options.scroll defaults to (0,0). Set `false` (not falsy) for no scroll
+ * @returns null
+ */
+const goto = (href, options={}) => {
 	if ( ! href) {
 		console.warn("goto: no href");
 		return;
 	}
 	window.history.pushState({}, "", href);
 	// scroll to the page top
-	window.scrollTo(0,0);
+	if (options && options.scroll==='false') {
+		// no scroll
+	} else {
+		window.scrollTo(0,0);
+	}
 	// update
 	DataStore.parseUrlVars(true);
 };
@@ -36,7 +47,9 @@ const A = (x) => {
 		stopEvent(e);
 		if (onClick) onClick(e);
 		// Allow onClick functions to stop our events too
-		if (!e.glrouterStopEvent) goto(href);
+		if ( !e.glrouterStopEvent) {
+			goto(href);
+		}
 	};
 	return <a href={href} onClick={doClick} {...args}>{children}</a>;
 };


### PR DESCRIPTION
If you save-as in Portal or MoneyScript it will (by default) switch you to editing the new file (as the user would expect).