### PR TITLE
Fix PropControlDataItem crunched inside portal's default .form-compact

### DIFF
--- a/base/components/DataItemBadge.jsx
+++ b/base/components/DataItemBadge.jsx
@@ -17,18 +17,16 @@ import KStatus from '../data/KStatus';
  * @param {?KStatus} p.status Only used if `item` isn't set.
  */
 const DataItemBadge = ({item, id, type, status=KStatus.PUBLISHED, onClick, href, className, ...rest}) => {
-    if ( ! item) {
-        let pvItem = getDataItem({type, id, status});
-        item = pvItem.value || {id, type};
-    }
-    const Tag = href? 'a' : 'div';
-    // if (href===true) { TODO if `true` then put together a url
-    //     href = getDataItemLink(item);
-    // }
-    return <Tag className="DataItemBadge" onClick={onClick} href={href} title={`ID: ${getId(item)}`}>
-        {getLogo(item) ? <img src={getLogo(item)} className="logo logo-sm" /> : <span className="d-inline-block logo logo-sm" />}{' '}
-        {getName(item) || getId(item)}
-    </Tag>;
+	if (!item) item = getDataItem({type, id, status}).value || {id, type};
+
+	const Tag = href ? 'a' : 'div';
+	// if (href === true) { // TODO if `true` then put together a url
+	//	href = getDataItemLink(item);
+	// }
+	return <Tag className="DataItemBadge" onClick={onClick} href={href} title={getName(item) || `ID: ${getId(item)}`}>
+	{getLogo(item) ? <img src={getLogo(item)} className="logo logo-sm" /> : <span className="d-inline-block logo logo-sm" />}{' '}
+	{getName(item) || getId(item)}
+	</Tag>;
 };
 
 // export const getDataItemLink = (item) => {

--- a/base/components/PropControlDataItem.jsx
+++ b/base/components/PropControlDataItem.jsx
@@ -69,12 +69,12 @@ const PropControlDataItem = ({canCreate, createProp="id", base, path, prop, prop
 
 	let onChange = e => {
 		let id = e.target.value;
-        //id = id.replace(/ $/g, "");
+		//id = id.replace(/ $/g, "");
 		setRawValue(id);
 		if (embed) {
 			return; // if embed, only set on-click
 		}
-        id = id.replace(/ $/g, "");
+		id = id.replace(/ $/g, "");
 		let mv = modelValueFromInput? modelValueFromInput(id, type, e, storeValue) : id;
 		DSsetValue(proppath, mv);
 	};
@@ -88,7 +88,7 @@ const PropControlDataItem = ({canCreate, createProp="id", base, path, prop, prop
 	};
 
 	const doClear = () => {
-		setRawValue('')
+		setRawValue('');
 		DSsetValue(proppath, '');
 	};
 
@@ -111,13 +111,13 @@ const PropControlDataItem = ({canCreate, createProp="id", base, path, prop, prop
 						>
 							<SlimListItem type={itemType} item={pvDataItem.value} noClick />
 						</Button>
-						{!readOnly && <Button color="secondary" onClick={doClear}>🗙</Button>}
+						{!readOnly && <Button color="secondary" className="clear" onClick={doClear}>🗙</Button>}
 					</ButtonGroup>
 					<div><small>ID: <code>{rawValue || storeValue}</code></small></div>
 				</Col>
 			</>}
-            <>
-				<Col md={8}>
+			<>
+				<Col xs={canCreate ? 8 : 12}>
 				<div className="dropdown-sizer">
 					<Input type="text" value={rawValue || storeValue || ''} onChange={onChange} />
 					{rawValue && showLL && <ListLoad className="items-dropdown card card-body" hideTotal type={itemType} status={status} 
@@ -130,7 +130,7 @@ const PropControlDataItem = ({canCreate, createProp="id", base, path, prop, prop
 					/>}
 				</div>
 			</Col>
-			<Col md={4}>
+			<Col xs={4}>
 				{canCreate && rawValue && (
 					<CreateButton type={itemType} base={base} id={baseId} saveFn={saveDraftFnFactory({type,key:prop})} then={({item}) => doSet(item)} />
 				)}

--- a/base/style/PropControl.less
+++ b/base/style/PropControl.less
@@ -231,12 +231,26 @@ You can apply it to, well, anything.
 // Non-link preview shouldn't look clickable
 span.preview .DataItemBadge {
 	cursor: default;
-
 }
 
 .data-item-control {
 	.dropdown-sizer {
 		position: relative; // This is a size/position reference for the floating dropdown list
+	}
+
+	// Ellipsize text label if it would overflow
+	.btn, .btn-group {
+		overflow: hidden;
+		max-width: 100%;
+	}
+	.btn.clear {
+		flex-shrink: 0; // squash text label but never X button
+	}
+	.DataItemBadge {
+		max-width: 100%;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		overflow: hidden;
 	}
 
 	// The autocomplete dropdown list
@@ -261,6 +275,22 @@ span.preview .DataItemBadge {
 	}
 }
 
+// .form-compact container scrunches everything
+.form-compact .data-item-control {
+	.btn {
+		padding: 0;
+	}
+
+	.DataItemBadge {
+		height: 100%;
+		padding: 0 0.25rem;
+		.logo {
+			height: 100%;
+			border: none;
+			margin-right: 0.25rem;
+		}
+	}
+}
 /* ./data-item-control */
 
 /* Modals */


### PR DESCRIPTION
Also ellipsize label if the item's name would overflow + change title / hover text to name (instead of ID) if available