### PR TITLE
Improve "unpublished edits" warning on PropControl

### DIFF
--- a/base/components/PropControl.jsx
+++ b/base/components/PropControl.jsx
@@ -11,14 +11,14 @@ import React, { useEffect, useRef, useState } from 'react';
 
 // FormControl removed in favour of basic <inputs> as that helped with input lag
 // TODO remove the rest of these
-import { Row, Col, Form, Button, Input, Label, FormGroup, InputGroup, InputGroupAddon, InputGroupText, Popover, PopoverBody, Modal, ModalBody } from 'reactstrap';
+import { Row, Col, Form, Button, Input, Label, FormGroup, InputGroup, InputGroupAddon, InputGroupText, Popover, PopoverBody, Modal, ModalBody, PopoverHeader, Table } from 'reactstrap';
 import _ from 'lodash';
 import Enum from 'easy-enums';
 import '../style/prism-dark.less';
 
 import { assert, assMatch } from '../utils/assert';
 import JSend from '../data/JSend';
-import { stopEvent, toTitleCase, space, labeller, is } from '../utils/miscutils';
+import { stopEvent, toTitleCase, space, labeller, is, ellipsize } from '../utils/miscutils';
 
 import { getDataItem } from '../plumbing/Crud';
 import KStatus from '../data/KStatus';
@@ -30,6 +30,7 @@ import { luminanceFromHex } from './Colour';
 import { nonce } from '../data/DataClass';
 
 import { countryListAlpha2 } from '../data/CountryRegion';
+import { CopyToClipboardButton } from '../../components/ExportControls';
 
 /**
    * Set the value and the modified flag in DataStore.
@@ -180,6 +181,92 @@ class PropControlParams {
 	warnOnUnpublished = true;
 }; // ./PropControlParams
 
+
+/* */
+const diffProp = (path, prop) => {
+	if (!path || path.length < 3) return null; // Must be a DataItem or part of one
+	const [status, type, id] = path || [];
+	if (!status || status !== 'draft') return null; // Must be a draft
+	if (!type || C.TYPES.isUser(type)) return null; // Ignore USER type, no need for login props
+
+	// Make sure both versions of the item are available locally
+	let pvDraft = getDataItem({ type, id, status: KStatus.DRAFT, swallow: true });
+	let pvPub = getDataItem({ type, id, status: KStatus.PUBLISHED, swallow: true });
+
+	// If the draft doesn't exist it can't have unpublished changes.
+	if (!pvDraft.value) return null;
+
+	if (prop === 'customcss') {
+		console.log('customcss');
+	}
+
+	// Never been published? Everything's unpublished changes!
+	if (!pvPub.value) {
+		return { status: KStatus.DRAFT };
+	}
+
+	// OK, so what's the actual difference for this prop?
+	const draftVal = DataStore.getValue([...path, prop]);
+	const pubVal = DataStore.getValue(['data', ...path.slice(1), prop]); // "data", not "published"
+
+	// No difference?
+	if (draftVal === pubVal) return null;
+
+	return { status: KStatus.MODIFIED, pubVal, draftVal };
+}
+
+
+const DiffWarning = ({path, prop, className}) => {
+	const diff = diffProp(path, prop);
+	if (!diff) return null;
+	// Don't spew visual noise on every PropControl for an unpublished item
+	// TODO Should we mark this anyway?
+	if (KStatus.isDRAFT(diff.status)) return null;
+
+	const [showPopover, setShowPopover] = useState(false);
+	const [id] = useState(() => `diff-${nonce()}`);
+	const popoverId = `${id}-popover`;
+	const toggle = () => {
+		// TODO Pull this out and have a SelfClosingPopover element
+		if (!showPopover) {
+			const maybeHidePopover = (e) => {
+				const popoverEl = document.getElementById(popoverId);
+				if (popoverEl.contains(e.target)) return;
+				setShowPopover(false);
+				document.body.removeEventListener('click', maybeHidePopover);
+			};
+			document.body.addEventListener('click', maybeHidePopover);
+		}
+		setShowPopover(!showPopover);
+	};
+
+	let pBody = null;
+	if (showPopover) {
+		const {pubVal, draftVal} = diff;
+		pBody = <PopoverBody>
+			<div className="diff-line mb-1">
+				<strong>Old</strong>
+				<code className="diff-val mx-1" title={ellipsize(pubVal, 100)}>{JSON.stringify(pubVal)}</code>
+				<CopyToClipboardButton size="sm" text={pubVal} />
+			</div>
+			<div className="diff-line">
+				<strong>New</strong>
+				<code className="diff-val mx-1" title={ellipsize(draftVal, 100)}>{JSON.stringify(draftVal)}</code>
+				<CopyToClipboardButton size="sm" text={pubVal} />
+			</div>
+		</PopoverBody>;
+	}
+
+
+
+	return <>
+		<Button id={id} className={space('data-modified', className)} onClick={toggle} title="Unpublished edits, click to see difference" />
+		<Popover id={popoverId} isOpen={showPopover} toggle={toggle} target={id} className="data-modified-details">
+			<PopoverHeader>Unpublished edit</PopoverHeader>
+			{pBody}
+		</Popover>
+	</>;
+};
 
 
 /**
@@ -390,12 +477,12 @@ const PropControl = ({ className, warnOnUnpublished = true, ...props }) => {
 				<label className={space(sizeClass, 'mr-1')} htmlFor={stuff.name}>{labelText} {helpIcon} {optreq}</label>}
 			{inline && ' '}
 			{help && !inline && !isCheck && <Help>{help}</Help>}
+			{warnOnUnpublished && <DiffWarning path={path} prop={prop} className="ml-1" />}
 			<PropControl2 storeValue={storeValue} value={value} rawValue={rawValue} setRawValue={setRawValue} proppath={proppath} {...props} pvalue={pvalue} />
 			{inline && ' '}
 			{help && (inline || isCheck) && <Help>{help}</Help>}
 			{error && <span className="help-block text-danger data-error">{error}</span>}
 			{warning && <span className="help-block text-warning data-warning">{warning}</span>}
-			{warnOnUnpublished && isModified(props) && <span className="help-block text-warning data-modified">Not Published Yet</span>}
 		</FormGroup>
 	);
 }; // ./PropControl

--- a/base/style/PropControl.less
+++ b/base/style/PropControl.less
@@ -9,6 +9,7 @@
 	background: repeating-linear-gradient(-45deg, #555, #555 6px, #ccc 6px, #ccc 12px);
 }
 
+
 // Define height of form-compact elements for reuse
 .form-compact-height() {
 	height: calc(1em + 0.7rem + 2px);
@@ -332,4 +333,32 @@ span.preview .DataItemBadge {
 .code-container {
 	display: block;
 	position: relative;
+}
+
+// Badge to mark a PropControl with unpublished edits
+.btn.data-modified {
+	background: repeating-linear-gradient(-45deg, #000, #000 4px, #ffc107 4px, #ffc107 8px);
+}
+.btn, .form-compact .btn {
+	&.data-modified {
+		padding: 0;
+		width: 1em;
+		height: 1em;
+	}
+}
+.data-modified-details {
+	.diff-line {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		max-width: 100%;
+	}
+	> :not(.diff-val) {
+		flex-shrink: 0;
+	}
+	.diff-val {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
 }


### PR DESCRIPTION
- Smaller (little badge inline with the label, rather than a large text label)
- More versatile (previous version could only diff top-level props on a DataItem, this one can index in arbitrarily)
- More informative (gives popover showing diff & clipboard button for pulling out bigger ones like customCSS)