### PR TITLE
Bugfix/2022 11/pcdi no premature set

### DIFF
--- a/base/components/PropControlDataItem.jsx
+++ b/base/components/PropControlDataItem.jsx
@@ -20,8 +20,8 @@ import DataItemBadge from './DataItemBadge';
 /**
  * TODO replace with DataItemBadge
  */
-const SlimListItem = ({item, onClick, noClick}) => {
-	return <DataItemBadge item={item} onClick={onClick} href={ ! noClick} />;
+const SlimListItem = ({item, onClick, noClick, ...props}) => {
+	return <DataItemBadge item={item} onClick={onClick} href={!noClick} {...props} />;
 };
 
 /**
@@ -71,7 +71,7 @@ const PropControlDataItem = ({canCreate, createProp="id", base, path, prop, prop
 	let onChange = e => {
 		let id = e.target.value;
 		setRawValue(id);
-		// signal "don't replace search box with item badge, even if this is a valid ID"
+		// signal "user is typing, don't replace search box with item badge, even if this is a valid ID"
 		setInputClean(false);
 		// if embed (store whole item, not just ID), only set modelvalue on-click
 		if (embed) return;
@@ -109,7 +109,7 @@ const PropControlDataItem = ({canCreate, createProp="id", base, path, prop, prop
 
 	return (
 		<Row className="data-item-control" onFocus={onFocus} onBlur={onBlur}>
-			{showItem && <>
+			{showItem ? (<>
 				<Col xs={12}>
 					<ButtonGroup>
 						<Button color="secondary" className="preview" tag={notALink ? 'span' : A}
@@ -122,19 +122,20 @@ const PropControlDataItem = ({canCreate, createProp="id", base, path, prop, prop
 					</ButtonGroup>
 					<div><small>ID: <code>{rawValue || storeValue}</code></small></div>
 				</Col>
-			</>}
-			<>
+			</>) : (<>
 				<Col xs={canCreate ? 8 : 12}>
 				<div className="dropdown-sizer">
-					{ !showItem && <Input type="text" value={rawValue || storeValue || ''} onChange={onChange} />}
-					{rawValue && showLL && <ListLoad className="items-dropdown card card-body" hideTotal type={itemType} status={status} 
-						domain={domain} filter={rawValue} unwrapped sort={sort} 
-						ListItem={SlimListItem}
-						// TODO allow ListLoad to show if there are only a few options
-						noResults={`No ${itemType} found for "${rawValue}"`}
-						pageSize={pageSize} otherParams={{filterByShares:true}}
-						onClickItem={item => doSet(item)}
-					/>}
+					<Input type="text" value={rawValue || storeValue || ''} onChange={onChange} />
+					{rawValue && true && <div className="items-dropdown card card-body">
+						<ListLoad hideTotal type={itemType} status={status}
+							domain={domain} filter={rawValue} unwrapped sort={sort}
+							ListItem={SlimListItem}
+							// TODO allow ListLoad to show if there are only a few options
+							noResults={`No ${itemType} found for "${rawValue}"`}
+							pageSize={pageSize} otherParams={{filterByShares:true}}
+							onClickItem={item => doSet(item)}
+						/>
+					</div>}
 				</div>
 			</Col>
 			<Col xs={4}>
@@ -142,7 +143,7 @@ const PropControlDataItem = ({canCreate, createProp="id", base, path, prop, prop
 					<CreateButton type={itemType} base={base} id={baseId} saveFn={saveDraftFnFactory({type,key:prop})} then={({item}) => doSet(item)} />
 				)}
 			</Col>
-		</>
+		</>)}
 		</Row>);
 };
 


### PR DESCRIPTION
Causes a behaviour change, so I'm calling for a sanity check before merge.
- If you type a valid item ID into its "search" box, PropControlDataItem will, without further interaction, turn your search box into a data-item badge.
- If you have - for instance - a campaign on the production portal with ID `T` (as we do), this can be a bad thing - especially as the search box doubles in many cases as a quick interface for creating a new data-item with a specified name.
- Old behaviour: I intend to create a test campaign and start typing "Test Campaign" --> I can't type any more because the PCDI says "Oh, `T`! I know this one! Here, I'll fill it in for you - no more search box."
- New behaviour: I type the first "T", PCDI's internal state says "The user has typed in the search box since the last time an item was picked - keep the search box open until they pick from the dropdown or click the Create button, even if it's a valid ID."