### PR TITLE
PropControlCode: place textarea in-flow

### DIFF
--- a/base/components/PropControls/PropControlCode.jsx
+++ b/base/components/PropControls/PropControlCode.jsx
@@ -1,79 +1,73 @@
-import React, { useRef } from 'react';
-
+import React, { useEffect, useRef } from 'react';
 import Prism from 'prismjs';
-import '../../style/prism-dark.less';
-
 import { DSsetValue, registerControl } from '../PropControl';
 
+import '../../style/prism-dark.less';
+import '../../style/PropControls/PropControlCode.less';
 
-const PropControlCode = ({ storeValue, prop, path, lang, onFocus: _onFocus, onChange: _onChange, onKeyDown: _onKeyDown, rawValue, setRawValue, ...otherStuff}) => {
-	// Tab should insert tab character instead of selecting next interactable element
-	const onKeyDown = (e) => {
-		if (e.key !== 'Tab') {
-			_onKeyDown && _onKeyDown(e);
-			return;
-		};
 
-		e.preventDefault();
-		const evtTarget = e.target;
-		const { selectionStart, selectionEnd } = evtTarget;
-		DSsetValue([...path, prop], storeValue.slice(0, selectionStart) + '\t' + storeValue.slice(selectionEnd));
-		setTimeout(() => {
-			evtTarget.setSelectionRange(selectionStart + 1, selectionStart + 1);
-			evtTarget.focus();
-			const codeEl = evtTarget.parentElement.querySelector('code');
-			setTimeout(() => Prism.highlightElement(codeEl));
-		}); // defer until after DataStore update redraws element & breaks caret pos / focus
+const PropControlCode = ({ storeValue, prop, path, lang, onFocus, onChange, onKeyDown, rawValue, setRawValue, ...otherStuff }) => {
+	const textRef = useRef(); // The mostly-invisible <textarea>
+	const codeRef = useRef(); // The <code> containing the highlighted text
+	const preRef = useRef(); // The <pre> containing the highlighter <code>
+
+	// Update highlighting in <code> element
+	const doHighlight = () => codeRef.current && Prism.highlightElement(codeRef.current);
+	// Match scrolling between <textarea> and <code>
+	const syncScroll = () => {
+		if (!preRef.current || !textRef.current) return;
+		preRef.current.scrollLeft = textRef.current.scrollLeft;
+		preRef.current.scrollTop = textRef.current.scrollTop;
 	};
 
-	// scroll the textarea & code at the same time
-	const onScroll = (e) => {
-		const inputEl = e.target.parentElement.querySelector('textarea');
-		const syntaxEl = e.target.parentElement.querySelector('pre');
-		syntaxEl.scrollLeft = inputEl.scrollLeft;
-		syntaxEl.scrollTop = inputEl.scrollTop;
-	};
-
-	const onChange = e => {
-		_onChange && _onChange(e);
-		const codeEl = e.target.parentElement.querySelector('code');
-		setTimeout(() => Prism.highlightElement(codeEl));
-	};
-
-	const onFocus = e => {
-		_onFocus && _onFocus(e);
-		const codeEl = e.target.parentElement.querySelector('code');
-		setTimeout(() => Prism.highlightElement(codeEl));
-	};
-
-	// Highlight the element once loaded
-	const codeRef = useRef();
-	React.useEffect((e) => {
-		if (codeRef.current)
-			setTimeout(() => Prism.highlightElement(codeRef.current));
+	// Highlight the <code> element as soon as it mounts
+	useEffect((e) => {
+			setTimeout(doHighlight);
 	}, [codeRef])
+
+	// Event handlers for <textarea>
+	const inputEvents = {
+		// Tab should insert tab character instead of selecting next interactable element
+		onKeyDown: (e) => {
+			onKeyDown && onKeyDown(e);
+			if (e.key !== 'Tab') return;
+			if (!textRef.current) return;
+
+			e.preventDefault();
+			const { selectionStart, selectionEnd } = textRef.current;
+			DSsetValue([...path, prop], storeValue.slice(0, selectionStart) + '\t' + storeValue.slice(selectionEnd));
+			setTimeout(() => {
+				textRef.current.setSelectionRange(selectionStart + 1, selectionStart + 1);
+				textRef.current.focus();
+				setTimeout(doHighlight);
+			}); // defer until after DataStore update redraws element & breaks caret pos / focus
+		},
+		// scroll the textarea & code at the same time
+		onScroll: syncScroll,
+		onChange: e => {
+			onChange && onChange(e);
+			setTimeout(doHighlight);
+		},
+		onFocus: e => {
+			onFocus && onFocus(e);
+			setTimeout(doHighlight);
+		},
+	};
 
 	// fix discrepency between last lines & stop undefined errors
 	const codeText = storeValue ? `${storeValue}\n ` : ' ';
 
 	return (
 		<div className="code-container">
-			<pre className="form-control syntax-highlighting">
-				<code className={`code-highlighting language-${lang}`} ref={codeRef} >
+			<pre className="syntax-highlighting" ref={preRef}>
+				<code className={`language-${lang}`} ref={codeRef}>
 					{codeText}
 				</code>
 			</pre>
 			<textarea
-				name={prop}
-				value={storeValue}
-				className="form-control code-input"
-				wrap="off"
-				spellCheck={false}
-				onKeyDown={onKeyDown}
-				onFocus={onFocus}
-				onScroll={onScroll}
-				onChange={onChange}
-				{...otherStuff}
+				className="form-control code-input" wrap="off" spellCheck={false}
+				name={prop} value={storeValue} ref={textRef}
+				{...inputEvents} {...otherStuff}
 			/>
 		</div>
 	);

--- a/base/style/PropControl.less
+++ b/base/style/PropControl.less
@@ -313,13 +313,6 @@ span.preview .DataItemBadge {
 .modal-content {
 	//height: 90vh; // Why?? This looks bad for e.g. the Add-a-Line chart editor in MoneyScript
 
-
-	/* if styled code in in the modal, make sure it's components are the same size */
-	.code-input, .syntax-highlighting, .code-highlighting {
-		width: 99% !important;
-		height: 80vh !important;
-	}
-
 	/* if text is in in the modal, make it take up enough space */
 	textarea, text {
 		max-width: 100% !important;
@@ -327,56 +320,6 @@ span.preview .DataItemBadge {
 	}
 }
 
-/* Syntax Highlighting */
-
-/* Syntax highlighting works by using a trasnparent text area that overlays a styling container which 
-   contains the tokenised & styled code. To work, the layers need to be pixel-exact. These rules ensure they are.
-   
-   Bootstraps styling kept messing this up and would override rules, resulting !importants are used here to make
-   sure the rules are followed  */
-.code-input,
-.syntax-highlighting,
-.code-highlighting {
-	font-size: inherit !important;
-	font-family: monospace !important;
-	line-height: inherit !important;
-	tab-size: 2 !important;
-	margin: 0.5em 0 !important;
-	padding: 1rem !important;
-	position: absolute;
-	width: 100%;
-	height: 100% !important;
-	top: 0;
-	left: 0;
-	border: none !important;
-	word-wrap: none;
-}
-
-/* invisible textarea input */
-.code-input {
-	background-color: transparent !important;
-	color: transparent !important;
-	caret-color: white;
-	resize: none;
-	padding-top: 1.5rem !important;
-	z-index: 1;
-}
-
-.syntax-highlighting {
-	z-index: 0;
-}
-
-.code-container {
-	height: 500px; // code blocks should be a good size, otherwise the single lines are fairly hard to read
-	display: block;
-	position: relative;
-}
-
-.modal-propControl-code {
-	.modal-content {
-		height: 90vh; // fixes modal being smaller than code blocks
-	}
-}
 
 // Toggle switch control
 .form-group .toggle-switch {

--- a/base/style/PropControls/PropControlCode.less
+++ b/base/style/PropControls/PropControlCode.less
@@ -49,10 +49,3 @@
 		tab-size: 2 !important;
 	}
 }
-
-// TODO This shouldn't be necessary now one of the elements is in-flow again
-.modal-propControl-code {
-	.modal-content {
-		height: 90vh; // fixes modal being smaller than code blocks
-	}
-}

--- a/base/style/PropControls/PropControlCode.less
+++ b/base/style/PropControls/PropControlCode.less
@@ -1,0 +1,58 @@
+/* Syntax Highlighting */
+
+/* Syntax highlighting works by using a trasnparent text area that overlays a styling container which 
+   contains the tokenised & styled code. To work, the layers need to be pixel-exact. These rules ensure they are.
+   
+   Bootstraps styling kept messing this up and would override rules, resulting !importants are used here to make
+   sure the rules are followed  */
+.form-group.code {
+	.code-container {
+		display: block;
+		position: relative;
+
+		// Textarea input
+		.code-input {
+			z-index: 1; // Put in front to receive pointer events & show caret/scrollbar
+			position: relative; // Enables z-index
+			min-height: 6em; // Reasonable smallest size for a multiline input
+			// Invisible except for scrollbars and caret
+			background-color: transparent !important;
+			color: transparent !important;
+			caret-color: white;
+		}
+
+		// Highlighting overlay
+		.syntax-highlighting {
+			z-index: 0; // position absolute but must be behind so textarea can take pointer events
+			// Fill box defined by textarea
+			position: absolute;
+			height: 100%;
+			width: 100%;
+			top: 0;
+			left: 0;
+		}
+	}
+
+	// All box and font metrics should be identical between textarea and highlighting
+	.code-input, .syntax-highlighting {
+		font-size: inherit !important;
+		font-family: monospace !important;
+		line-height: inherit !important;
+		margin: 0;
+		padding: 0.5em !important;
+		word-wrap: none;
+		border-width: 1px; // Override Prism, match ours
+	}
+
+	// Tab size doesn't inherit to the <code> element from .syntax-highlighting
+	.code-input, .syntax-highlighting code {
+		tab-size: 2 !important;
+	}
+}
+
+// TODO This shouldn't be necessary now one of the elements is in-flow again
+.modal-propControl-code {
+	.modal-content {
+		height: 90vh; // fixes modal being smaller than code blocks
+	}
+}


### PR DESCRIPTION
See the CSS box at the bottom of the Design tab on a Campaign page for why this is important.
Also allows it to assume its natural height - which means resizing can be enabled again.