### PR TITLE
fixed ghosting bug on firefox

### DIFF
--- a/base/style/PropControls/PropControlCode.less
+++ b/base/style/PropControls/PropControlCode.less
@@ -19,6 +19,7 @@
 			background-color: transparent !important;
 			color: transparent !important;
 			caret-color: white;
+			text-shadow: none !important;
 		}
 
 		// Highlighting overlay

--- a/base/style/prism-dark.less
+++ b/base/style/prism-dark.less
@@ -1,7 +1,7 @@
 code[class*=language-] {
 	color: #fff;
 	background: 0 0;
-	font-family: Consolas,Monaco,'Andale Mono','Ubuntu Mono',monospace;
+	font-family: monospace;
 	font-size: 1em;
 	text-align: left;
 	text-shadow: none;


### PR DESCRIPTION
firefox was setting textshadow when textarea was focused & not setting the inside of "pre" to the correct font, giving us the ghosting effect