### PR TITLE
PropControlDataItem: don't retain picked value

### DIFF
--- a/base/components/PropControlDataItem.jsx
+++ b/base/components/PropControlDataItem.jsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import _ from 'lodash';
 import { Input, Row, Col, Dropdown, DropdownItem, DropdownMenu, DropdownToggle, Button, ButtonGroup } from 'reactstrap';
 
@@ -43,6 +43,11 @@ const PropControlDataItem = ({canCreate, createProp="id", base, path, prop, prop
 	let [showLL, setShowLL] = useState(); // Show/hide ListLoad
 	const [, setCloseTimeout] = useState(); // Debounce hiding the ListLoad
 	const [inputClean, setInputClean] = useState(true); // Has the user input anything since last pick?
+
+	// If storevalue is nulled out from elsewhere, don't retain rawValue
+	useEffect(() => {
+		if (!storeValue) setRawValue('');
+	}, [storeValue]);
 
 	// In React pre-v17, onFocus/onBlur events bubble - BUT:
 	// When focus shifts WITHIN the listener, a blur/focus event pair is fired.


### PR DESCRIPTION
Fixes the case in portal where a Charity object is nulled out so its ID (storeValue for this component) is also null - but the PCDI still has a rawValue stored in useState, so it doesn't automatically turn back to a search box.