### PR TITLE
Bugfix/2022 12/viewcountbycampaign handle empty

### DIFF
--- a/base/data/Advert.js
+++ b/base/data/Advert.js
@@ -135,7 +135,15 @@ Advert.charityList = ad => {
 	return clist; 
 };
 
+/**
+ * @param {Item[]} ads 
+ * @returns {object} viewcount4campaign
+ */
 Advert.viewcountByCampaign = ads => {
+	if (!ads || ads.length === 0) {
+		console.error('ads is empty')
+		return {}
+	}
 	// Get ad viewing data
 	let sq = new SearchQuery("evt:minview");
 	let qads = ads.map(({ id }) => `vert:${id}`).join(' OR ');

--- a/base/data/Advert.js
+++ b/base/data/Advert.js
@@ -141,7 +141,7 @@ Advert.charityList = ad => {
  */
 Advert.viewcountByCampaign = ads => {
 	if (!ads || ads.length === 0) {
-		console.error('ads is empty')
+		console.log('ads is empty')
 		return {}
 	}
 	// Get ad viewing data


### PR DESCRIPTION
Advert.viewcountByCampaign will now return an empty object if it got empty input, instead of just querying everything. 