### PR TITLE
Remove jwt in url after logged in to avoid logging in again after ref…

### DIFF
--- a/base/youagain.js
+++ b/base/youagain.js
@@ -192,6 +192,10 @@ class _Login {
 				// 50X? no-op
 				return res;
 			});
+		// Remove jwt in url after logged in to avoid logging in again after refresh
+		if (jwt) {
+			window.history.pushState({}, '', window.location.pathname + window.location.search.replace('jwt='+jwt, ''))
+		}
 		return pVerify;
 	};
 


### PR DESCRIPTION
I wrote some automated test using selenium. After testing, I don't think there is a real "bug". The cannot logout issue might caused by refreshing the url with jwt in it. This would remove the jwt in url after use to prevent confusion in the case of a refresh. 