### PR TITLE
eslintrc tweak

### DIFF
--- a/project/.eslintrc.js
+++ b/project/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
 		es6: false,
 		browser: true
 	},
-	 globals: { // these are needed to avoid errors in puppeteer/node files
+	globals: { // these are needed to avoid errors in puppeteer/node files
 		window: true,
 		document: true,
 		page: true,
@@ -19,7 +19,10 @@ module.exports = {
 		sourceType: "module",
 		ecmaFeatures: {
 			jsx: true
-		}
+		},
+		babelOptions: {
+			presets: ["@babel/preset-react"]
+		},
 	},
 	extends: "airbnb",
 	plugins: [


### PR DESCRIPTION
Fixes the ESLint error: `This experimental syntax requires enabling one of the following parser plugin(s): 'jsx, flow, typescript'`