### PR TITLE
canReadItem now also checks against canonical XIds now in order to support legacy users

### DIFF
--- a/base/components/ListLoad.jsx
+++ b/base/components/ListLoad.jsx
@@ -475,7 +475,7 @@ const DefaultCopy = ({ type, id, item, list, onCopy }) => {
  * @param {!string} id 
  * @returns {!string}
  */
-const id2canonical = id => id.toLowerCase().replace('&', "and").replace(/[^a-zA-Z0-9]/g,'-');
+export const id2canonical = id => id.toLowerCase().replace('&', "and").replace(/[^a-zA-Z0-9]/g,'-');
 
 /**
  * Make a local blank, and set the nav url


### PR DESCRIPTION
See: https://github.com/good-loop/adserver/pull/120