### PR TITLE
PropControlUpload recognises .webp as acceptable image file

### DIFF
--- a/base/components/PropControls/PropControlUpload.jsx
+++ b/base/components/PropControls/PropControlUpload.jsx
@@ -15,7 +15,7 @@ import ServerIO from '../../plumbing/ServerIOBase';
 
 
 /** MIME type sets */
-const imgTypes = '.jpg, .jpeg, image/jpeg, .png, image/png, .svg, image/svg+xml';
+const imgTypes = '.jpg, .jpeg, image/jpeg, .png, image/png, .svg, image/svg+xml, .webp, image/webp';
 const videoTypes = '.mp4, .m4v, video/mp4, .ogv, video/ogg, .avi, video/x-msvideo, .wmv, video/x-ms-wmv, .mov, video/quicktime, .asf, video/ms-asf';
 const fontTypes = '.ttf, font/ttf, .otf, font/otf, .woff, font/woff, .woff2, font/woff2';
 const spreadsheetTypes = '.csv'; // TODO Excel and -- maybe using libreoffice as the backend convertor to csv? Or the Apache Something library?


### PR DESCRIPTION
Didn't add it to the help text for the sake of brevity, but it's been added to the list as both extension and MIME type.