### PR TITLE
Add BlindUpload control

### DIFF
--- a/base/components/BlindUpload.jsx
+++ b/base/components/BlindUpload.jsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { useDropzone } from 'react-dropzone';
+
+import { UploadProgress } from './propcontrols/PropControlUpload';
+
+/**
+ * An upload widget that doesn't act as a URL input, it just sends the file to the endpoint and executes any provided callback.
+ */
+function BlindUpload({endpoint, uploadParams, onUpload, label}) {
+	const [uploading, setUploading] = useState(false);
+
+	// When file picked/dropped, upload to the media cluster
+	const onDrop = (accepted, rejected) => {
+		// Update progress readout - use updater function to merge start time into new object
+		const progress = ({ loaded, total }) => setUploading(({start}) => ({ start, loaded, total }));
+		// Upload complete = delete progress readout
+		const load = () => setUploading(false);
+
+		accepted.forEach(file => {
+			const uploadOptions = {};
+			if (uploadParams) uploadOptions.params = uploadParams;
+			if (endpoint) uploadOptions.endpoint = endpoint;
+
+			ServerIO.upload(file, progress, load, uploadOptions)
+				.done(response => onUpload && onUpload(response))
+				.fail(res => res.status == 413 && notifyUser(new Error(res.statusText)));
+				// Record start time of current upload
+				setUploading({start: new Date().getTime()});
+		});
+		// TODO Inform the user that their file had a Problem
+		rejected.forEach(file => console.error("rejected :( " + file));
+	};
+
+	// New hooks-based DropZone - give it your upload specs & an upload-accepting function, receive props-generating functions
+	const { getRootProps, getInputProps } = useDropzone({accept: null, onDrop, disabled: false});
+
+	return (
+		<div className="DropZone" {...getRootProps()}>
+			<input {...getInputProps()} />
+			<small>{label}</small>
+			{uploading ? <UploadProgress {...uploading} /> : null}
+		</div>
+	);
+};
+
+export default BlindUpload;

--- a/base/components/propcontrols/PropControlUpload.jsx
+++ b/base/components/propcontrols/PropControlUpload.jsx
@@ -33,7 +33,7 @@ const acceptTypes = {
 	videoUpload: videoTypes,
 	bothUpload: `${imgTypes}, ${videoTypes}`,
 	fontUpload: fontTypes,
-	spreadsheetUpload: spreadsheetTypes
+	spreadsheetUpload: spreadsheetTypes,
 };
 
 
@@ -93,7 +93,7 @@ const bytes = b => {
  * @param {Number} loaded Bytes sent so far
  * @param {Number} total Total size of file in bytes
  */
-const UploadProgress = ({ start, loaded = 0, total }) => {
+export const UploadProgress = ({ start, loaded = 0, total }) => {
 	if (!start) return null;
 	if (!total) return 'Starting upload...';
 


### PR DESCRIPTION
Submits a file but doesn't put the response in a URL field / no implicit DataStore binding.
Used by MeasurePage in corresponding adserver branch.

Down the line, it probably makes sense to keep upload / dropzone logic only in here & import in PropControlUpload?