### PR TITLE
print period start end translate to local

### DIFF
--- a/base/utils/date-utils.ts
+++ b/base/utils/date-utils.ts
@@ -232,8 +232,14 @@ export const printPeriod = ({start, end, name}:Period, short=false) => {
 	end = new Date(end);
 	end.setSeconds(end.getSeconds() - 1);
 
+	// Prevent browsers in non UTC/ GMT Timezone shift the printing of the date
+	// E.g. 2023-03-28T23:59:59Z became 2023-03-29T07:59:59Z in Asia
+	const timezoneOffsetInMinutes = start.getTimezoneOffset();
+	const localStart = new Date(start.getTime() + timezoneOffsetInMinutes * 60 * 1000);
+	const localEnd = new Date(end.getTime() + timezoneOffsetInMinutes * 60 * 1000);
+
 	const pd = short ? printDateShort : dateStr;
-	return `${start ? pd(start) : ``} to ${end ? pd(end) : `now`}`;
+	return `${localStart ? pd(localStart) : ``} to ${localEnd ? pd(localEnd) : `now`}`;
 };
 
 // export const periodKey = ({start, end, name}) : String => {

--- a/base/utils/date-utils.ts
+++ b/base/utils/date-utils.ts
@@ -234,12 +234,11 @@ export const printPeriod = ({start, end, name}:Period, short=false) => {
 
 	// Prevent browsers in non UTC/ GMT Timezone shift the printing of the date
 	// E.g. 2023-03-28T23:59:59Z became 2023-03-29T07:59:59Z in Asia
-	const timezoneOffsetInMinutes = start.getTimezoneOffset();
-	const localStart = new Date(start.getTime() + timezoneOffsetInMinutes * 60 * 1000);
-	const localEnd = new Date(end.getTime() + timezoneOffsetInMinutes * 60 * 1000);
+	const startUTC = `${start.getUTCDate().toString()} ${shortMonths[start.getUTCMonth()]} ${start.getFullYear()}`;
+	const endUTC = `${end.getUTCDate().toString()} ${shortMonths[end.getUTCMonth()]} ${end.getFullYear()}`;
 
-	const pd = short ? printDateShort : dateStr;
-	return `${localStart ? pd(localStart) : ``} to ${localEnd ? pd(localEnd) : `now`}`;
+	// const pd = short ? printDateShort : dateStr;
+	return `${startUTC || ``} to ${endUTC || `now`}`;
 };
 
 // export const periodKey = ({start, end, name}) : String => {

--- a/base/utils/date-utils.ts
+++ b/base/utils/date-utils.ts
@@ -234,10 +234,13 @@ export const printPeriod = ({start, end, name}:Period, short=false) => {
 
 	// Prevent browsers in non UTC/ GMT Timezone shift the printing of the date
 	// E.g. 2023-03-28T23:59:59Z became 2023-03-29T07:59:59Z in Asia
-	const startUTC = `${start.getUTCDate().toString()} ${shortMonths[start.getUTCMonth()]} ${start.getFullYear()}`;
-	const endUTC = `${end.getUTCDate().toString()} ${shortMonths[end.getUTCMonth()]} ${end.getFullYear()}`;
+	let startUTC = `${start.getUTCDate().toString()} ${shortMonths[start.getUTCMonth()]} ${start.getFullYear()}`;
+	let endUTC = `${end.getUTCDate().toString()} ${shortMonths[end.getUTCMonth()]} ${end.getFullYear()}`;
 
-	// const pd = short ? printDateShort : dateStr;
+	if (short) {
+		startUTC = startUTC.substring(0, startUTC.length-5);
+		endUTC = endUTC.substring(0, endUTC.length-5);
+	}
 	return `${startUTC || ``} to ${endUTC || `now`}`;
 };
 


### PR DESCRIPTION
Fixing an issue when we print the start/ end date in dashboard.
<img width="418" alt="image" src="https://user-images.githubusercontent.com/22352872/230306503-03efed0f-22a7-4a38-9ff1-416a4bc03a65.png">

When we create `new Date(dateString)` in JavaScript. I will default to use the UTC +0 timezone. When we try to print the date in the browser, if our timezone is not UTC, the browser will adjust the time accordingly. i.e. The time will be +1 in BST time, or +7 in Hong Kong Time. 

This PR is to make our date object print as UTC. So the date shown in dashboard will be consistent whatever timezone you're in. 