### PR TITLE
Feature/2023 04/greendash timezone support

### DIFF
--- a/base/utils/date-utils.ts
+++ b/base/utils/date-utils.ts
@@ -257,6 +257,8 @@ export const printPeriod = ({ start, end, name, timezone }: Period, short = fals
 	return `${startPrint || ``} to ${endPrint || `now`}`;
 };
 
+export const padZero = (num: number): string => num < 10 ? `0${num}` : `${num}`;
+
 // export const periodKey = ({start, end, name}) : String => {
 // 	if (name) return name;
 // 	return `${start ? isoDate(start) : 'forever'}-to-${end ? isoDate(end) : 'now'}`
@@ -267,3 +269,4 @@ const monthRegex = /^(\d\d?\d?\d?)-(\d\d?)$/;
 const yearRegex = /^(\d\d?\d?\d?)$/;
 
 const dateFormatRegex: RegExp = /^\d{4}-\d{2}-\d{2}$/;
+


### PR DESCRIPTION
`date-utils` to use `moment-timezone`. 
@athomson0 Please be ware that all of our project that use `date-utils`, including portal will have to install `"moment-timezone": "^0.5.43",` after merging this PR. 
Update: I will go update the package.json of the affect repos. 