### PR TITLE
WIP (add large data handling in ListLoad) CRUD functions: automatically break down large list requests

### DIFF
--- a/base/style/ListLoad.less
+++ b/base/style/ListLoad.less
@@ -10,6 +10,23 @@
 		justify-content: space-evenly;
 		margin: 0.5em;
 	}
+
+	// Expand / squeeze pagination items to fill container
+	// ...once we measure their natural size & can estimate how many will fit.
+	.pager {
+		visibility: hidden;
+		&.measured {
+			visibility: visible;
+			// squeeze
+			.page-item {
+				flex-shrink: 1;
+				flex-grow: 1;
+			}
+			.page-link {
+				width: 100%;
+			}
+		}
+	}
 }
 
 


### PR DESCRIPTION
- Detects when the hits count on a list-by-query is smaller than the actual item count, and fires off additional list requests with start-from-index param to get the rest of the items
- Preempts "too many IDs" error by breaking list-by-IDs requests into batches of 100 items

Effects can be seen at:
- Portal #advert page: all 2200+ items are loaded rather than silently pulling 1000 (cut to 500-odd with post-filtering)
- Green dashboard filters: all 1200+ campaigns are now loaded in the dropdown (previously cut to 1000)
- Green tag generator: should fix 431 error + incomplete CSV when exporting full unfiltered tag list