### PR TITLE
bugfix/2023-06/advert-impactSetting-fix

### DIFF
--- a/base/data/Advert.js
+++ b/base/data/Advert.js
@@ -109,9 +109,8 @@ Advert.hideFromShowcase = ad => ad.hideFromShowcase;
 
 Advert.isHiddenFromImpact = (ad, impactSettings) => {
 	assert(ad);
-	assert(impactSettings);
 	if (ad.hideFromShowcase) return ad.id;
-	if (!impactSettings.showNonServedAds && !Advert.served(ad)) return "non-served";
+	if (impactSettings && !impactSettings.showNonServedAds && !Advert.served(ad)) return "non-served";
 }
 
 /**


### PR DESCRIPTION
the page that generates impactSettings also has a component that asserts that impactSettings exist - causing a consistent crash. I don't believe the assert is actually needed but I can't seem to replicate the error locally annoyingly so this is untested. However, it only affects the page that was crashing anyways since the method isn't called anywhere else. 