### PR TITLE
changed viewcount to return 0 instead of empty obj

### DIFF
--- a/base/data/Campaign.js
+++ b/base/data/Campaign.js
@@ -222,7 +222,7 @@ Campaign.viewcount = ({campaign, status}) => {
 	if (!pvAds.resolved) return null; // best we can do without big refactor: signify "answer not ready yet"
 
 	const ads = List.hits(pvAds.value) || [];
-	if (!ads?.length) return {}; // Empty campaign - stop before Advert.viewcountByCountry spams the console
+	if (!ads?.length) return 0; // Empty campaign - stop before Advert.viewcountByCountry spams the console
 
 	const viewcount4campaign = Advert.viewcountByCampaign(ads);
 	return sum(Object.values(viewcount4campaign));


### PR DESCRIPTION
@roscoemcinerney pinging you in since I know you have been recently changing how we grab viewcounts. Previously if the campaign had no ads then an empty object would be returned - causing issues when summing over a list of campaigns. Was there a reason for this to be an empty object instead of 0? 