### PR TITLE
Make the data item value empty on removal, not deleted

### DIFF
--- a/base/components/propcontrols/PropControlDataItem.jsx
+++ b/base/components/propcontrols/PropControlDataItem.jsx
@@ -108,7 +108,7 @@ setRawValue, storeValue, modelValueFromInput,
 
 	const doClear = () => {
 		setRawValue('');
-		set(null);
+		set('');
 		// DSsetValue(proppath, '');
 	};
 


### PR DESCRIPTION
If the empty value is not preserved, changes will not be saved properly as the value will get merged back in on publish, see https://good-loop.monday.com/boards/2603585504/views/60487313/pulses/4512758505