### PR TITLE
Creative recs: use correct format params when calling /recompress

### DIFF
--- a/base/components/creative-recommendations/processImage.js
+++ b/base/components/creative-recommendations/processImage.js
@@ -72,14 +72,18 @@ function recompress(transfer, {width, height}) {
 		return processLocal(transfer, 'image', { unused: true });
 	}
 
-	// Get options
+	// Get global options
 	const { noWebp = false, retinaMultiplier = 1} = DataStore.getValue(RECS_OPTIONS_PATH);
 
-	// Apply 1x / 1.5x / 2x multiplier before coercing size to integer
-	width = Math.floor(retinaMultiplier * width);
-	height = Math.floor(retinaMultiplier * height);
+	const params = {
+		// Apply 1x / 1.5x / 2x multiplier before coercing size to integer
+		width: Math.floor(retinaMultiplier * width),
+		height: Math.floor(retinaMultiplier * height),
+		format: noWebp ? '' : 'webp'
+	};
 
-	return callRecompressServlet(transfer, 'image', { width, height, noWebp });
+
+	return callRecompressServlet(transfer, 'image', params);
 }
 
 


### PR DESCRIPTION
When "noWebp" control is unchecked, send request with `format=webp` - when checked, send with `format=''`. 
Depends on server-side change https://github.com/good-loop/adserver/pull/204 (default to original image format) to work properly.