### PR TITLE
Creative recs: don't try to show extra-details modal for unused images

### DIFF
--- a/base/components/PageRecommendations.jsx
+++ b/base/components/PageRecommendations.jsx
@@ -171,6 +171,9 @@ function ImgRecDetails({spec}) {
 	const [showOriginal, setShowOriginal] = useState(false);
 	const toggle = () => setOpen(a => !a);
 
+	// No details to show for images that analysis suggests are unused.
+	if (spec.unused) return null;
+
 	// TODO controls for retina, no-scale, etc
 
 	const { url, optUrl, imgEl } = spec;


### PR DESCRIPTION
The information in the modal depends almost entirely on knowing how the image is used in-page, if it appears to be unused there's nothing to see (and an NPE to throw).