### PR TITLE
Creative recommendations: load images through proxy

### DIFF
--- a/base/components/PageRecommendations.jsx
+++ b/base/components/PageRecommendations.jsx
@@ -221,7 +221,9 @@ function ImgRecDetails({spec}) {
 	// TODO controls for retina, no-scale, etc
 	// - can we support changing compression params without losing all data & returning to main screen?
 
-	const { url, optUrl, imgEl } = spec;
+	let { url, optUrl, imgEl } = spec;
+	url = proxy(url); // Circumvent adblock and Firefox Enhanced Tracking Protection
+
 	let { width, height } = spec.elements[0];
 	const imgStyle = { maxWidth: width, maxHeight: height };
 
@@ -270,7 +272,8 @@ function ImgRecDetails({spec}) {
 
 /** Show the optimisations performed on one image file */
 export function ImgRecommendation({spec}) {
-	const { url } = spec;
+	let { url } = spec;
+	url = proxy(url); // Circumvent adblock and Firefox Enhanced Tracking Protection
 
 	return <Card className="opt-rec img-rec">
 		<CardHeader>Image</CardHeader>
@@ -288,7 +291,8 @@ export function ImgRecommendation({spec}) {
 
 /** Show the optimisations performed on one GIF file */
 export function GifRecommendation({spec}) {
-	const { url } = spec;
+	let { url } = spec;
+	url = proxy(url); // Circumvent adblock and Firefox Enhanced Tracking Protection
 
 	return <Card className="opt-rec gif-rec">
 		<CardHeader>GIF</CardHeader>
@@ -304,7 +308,8 @@ export function GifRecommendation({spec}) {
 
 /** Show the optimisations performed on one SVG file */
 export function SvgRecommendation({spec}) {
-	const { url } = spec;
+	let { url } = spec;
+	url = proxy(url); // Circumvent adblock and Firefox Enhanced Tracking Protection
 
 	return <Card className="opt-rec svg-rec">
 		<CardHeader>SVG Image</CardHeader>
@@ -336,8 +341,6 @@ export function ScriptRecommendation({spec}) {
 
 /** Special case for "There's nothing for us to do here" */
 export function NoRecommendation({spec}) {
-	const { filename } = spec;
-
 	return <Card className="opt-rec no-rec">
 		<CardHeader title={spec.message}>No Reduction</CardHeader>
 		<CardBody className="p-2">

--- a/base/components/creative-recommendations/processImage.js
+++ b/base/components/creative-recommendations/processImage.js
@@ -1,4 +1,5 @@
 import DataStore from '../../plumbing/DataStore';
+import { proxy } from '../../utils/pageAnalysisUtils';
 import { callRecompressServlet, processLocal } from './processGeneric';
 import { RECS_OPTIONS_PATH } from './recommendation-utils';
 
@@ -42,7 +43,7 @@ function loadImage(url) {
 		const img = new Image();
 		img.addEventListener('load', () => resolve(img));
 		img.addEventListener('error', err => reject(err));
-		img.src = url;
+		img.src = proxy(url); // Circumvent adblock and Firefox Enhanced Tracking Protection
 	});
 }
 


### PR DESCRIPTION
Some ad images are unsurprisingly on URLs trigger Firefox Enhanced Tracking Protection - this stops us loading them during the recommendation generation / preview process. Immediate fix is to load them through FileProxyServlet.