### PR TITLE
ListLoad pagination: infinite recursion on 4-page list

### DIFF
--- a/base/components/Pager.jsx
+++ b/base/components/Pager.jsx
@@ -1,7 +1,9 @@
-import { keyBy, range } from 'lodash';
-import React, {useState, useEffect } from 'react';
-import { space } from '../utils/miscutils';
+import React, { useState, useEffect } from 'react';
+
+import { range } from 'lodash';
 import { Pagination, PaginationItem, PaginationLink } from 'reactstrap';
+
+import { space } from '../utils/miscutils';
 
 import '../style/Pager.less';
 
@@ -14,6 +16,12 @@ import '../style/Pager.less';
  * @returns {boolean}
  */
 const isOptional = (page, current, pageCount) => {
+	// The "first, last, current, one either side, and only when it reduces the item count" rule
+	// means no buttons will ever be skipped when there are 4 pages or fewer.
+	// Also at 4 pages the "only hide 2 if 3 is optional" and "only hide N-1 if N-2 is optional"
+	// checks overlap and can recurse infinitely alternately checking 2 and 3...
+	if (pageCount < 5) return false;
+	// Special buttons always displayed
 	if (typeof page !== 'number') return false;
 	// First, last, current, and 1 button either side of current are always shown no matter what.
 	if ([1, current - 1, current, current + 1, pageCount].includes(page)) return false;


### PR DESCRIPTION
The rules for skipping buttons in the pagination controls say:
- Always show buttons for first, last, current page, and one page on either side of current
- Only skip pages if it would reduce the number of buttons - eg don't bother shortening {1 2 3 [4] 5} to {1 … 3 [4] 5}

The second rule is implemented as
- "Button 2 is only optional if button 3 is too"
- "Button N-1 is only optional if button N-2 is too".

At 4 pages, this becomes "2 is optional only if 3 is" and "3 is only optional if 2 is".
This SHOULD be fine, since either the 2 or 3 case (or both) should be short-circuited before they reach those checks if any of pages 1-4 is selected.
However! Components invoking Pager manage their own page selection & just pass it a `setPage` callback, so they can have "illegal" values for `current`, which Pager should tolerate.