### PR TITLE
filter ads to ones that have ran & are part of campaigns

### DIFF
--- a/base/data/ImpactPageData.js
+++ b/base/data/ImpactPageData.js
@@ -128,6 +128,9 @@ const fetchImpactBaseObjects2 = async ({itemId, itemType, status, start, end}) =
 
 	// Collect, de-duplicate, and sort
 	ads = uniqBy(ads, 'id');
+	// we only care for ads that are actually part of campaigns & have ran before
+	ads = ads.filter(ad => Advert.served(ad) && !ad.hideFromShowcase && campaignIds.includes(ad.campaign))
+
 	ads.sort(alphabetSort);
 	// greenTags = uniqBy(greenTags, 'id');
 	// greenTags.sort(alphabetSort);


### PR DESCRIPTION
We were getting ads that weren't attached to campaigns & ads that hadn't ran before. This extra filter will clean those out