### PR TITLE
removed breaking var from useEffect

### DIFF
--- a/base/components/Pager.jsx
+++ b/base/components/Pager.jsx
@@ -91,7 +91,7 @@ function Pager({pageCount, current, setPage, ...baseProps}) {
 	useEffect(() => {
 		setButtonProps(initButtonProps({pageCount, ...baseProps}));
 		setMeasured(false); // Measurements invalidated, so redo them.
-	}, [pageCount, pagerWidth]);
+	}, [pageCount]);
 
 	// Measure button elements and store width of each on corresponding props object
 	useEffect(() => {


### PR DESCRIPTION
Some ListLoads with large amount (>5) have been lagging a good bit, flashing until they eventually freeze the page. I think I found the issue but I've got a few questions about it. 

As far as I understand it, we watch for the size of the list so we can add in page numbers & then mark it as measured. We then add in our page numbers.

The issue then arises from he fact that this changes the size of the element, meaning it needs remeasured. Since it isn't measured, we take out the page numbers (since we don't know what size & how many to use) & measure the page. Then we're back at the start of this loop.

To replicate the issue, head to https://portal.good-loop.com/?filter=#green -> bulk upload -> change the brand field

I'm a wee bit unsure on what situation where we'd need to remeasure this after the initial measurement? This PR might end up breaking this case. 