### PR TITLE
send-verify - pass app + dataspace

### DIFF
--- a/base/components/LoginWidget.jsx
+++ b/base/components/LoginWidget.jsx
@@ -353,7 +353,7 @@ function EmailSignin({verb, onLogin, onRegister, onSubmit, onError, canRegister,
 	let $errorCTA;
 	if (Login.error?.text?.toLowerCase().includes("unverified")) {
 		let email = DataStore.getValue(path.concat("email"));
-		$errorCTA = <a href={Login.ENDPOINT+"?action=send-verify&email="+encURI(email)}>Resend email verification</a>;
+		$errorCTA = <a href={Login.ENDPOINT+"?action=send-verify&email="+encURI(email)+"&app="+encURI(C.app.id)+"&d="+encURI(C.app.dataspace)}>Resend email verification</a>;
 	}
 
 	// login/register


### PR DESCRIPTION
When clicking the `send-verify` link on stageportal for re-sending the verification link, YouAgain throws a 500 because we aren't providing it with an `app` parameter:  

```
 java.lang.NullPointerException: Argument 0 in stg@test.com@email
    at com.winterwell.utils.Utils.check4null(Utils.java:64)
    at com.winterwell.youagain.data.DB.findAuth(DB.java:48)
    at com.winterwell.youagain.YouAgainServlet.doSendEmailVerify(YouAgainServlet.java:539)
```

DB.java:48:
```
Utils.check4null(app, xid);
```

I _think_ using C.app is the correct way to pass this, if not please let me know!

Thanks,
Aidan
