### PR TITLE
Refactor how ServerIO overrides are compiled in

### DIFF
--- a/base/plumbing/ServerIOBase.js
+++ b/base/plumbing/ServerIOBase.js
@@ -75,12 +75,15 @@ ServerIO.checkBase = () => {
 	// e.g. process.env.SERVERIO_OVERRIDES finds a usable value.
 	// So instead of trying to determine if it exists, just swallow errors when it doesn't.
 	try {
-		const ServerIOOverrides = process.env.SERVERIO_OVERRIDES; // NB: see webpack.config.js for how this is set
-		if (ServerIOOverrides) {
-			Object.entries(ServerIOOverrides).forEach(([key, val]) => {
-				ServerIO[key] = val;
-				console.log("SERVERIOOVERRIDE", key, val);
-			});
+		if (process.env.CONFIG_FILE) {
+			const { ServerIOOverrides } = require(process.env.CONFIG_FILE);
+			// const ServerIOOverrides = process.env.SERVERIO_OVERRIDES; // NB: see webpack.config.js for how this is set
+			if (ServerIOOverrides) {
+				Object.entries(ServerIOOverrides).forEach(([key, val]) => {
+					ServerIO[key] = val;
+					console.log('SERVERIOOVERRIDE', key, val);
+				});
+			}
 		}
 	} catch (e) {} // Ignore "process is undefined" etc errors
 

--- a/template/config/template_serverio_overrides.js
+++ b/template/config/template_serverio_overrides.js
@@ -1,23 +1,27 @@
 // Copy this file to $YOURHOSTNAME.js and re-run webpack to override constants in ServerIO.
+// After creating the file, further changes will be detected by webpack and trigger a rebuild.
 // You don't have to commit it, but it won't affect any other machines if you do.
 // The setup below is only an example - you can mix and match servers and hardcode whatever you want.
 
-// Change to "local", "test" or "" to switch all endpoints together
-const cluster = 'test';
-const protocol = (cluster === 'local') ? 'http' : 'https';
+// Change index to switch all endpoints together
+const cluster = ['', 'stage', 'test', 'local'][2];
 
-module.exports = {
-	ServerIOOverrides: {
-    APIBASE: `${protocol}://${cluster}portal.good-loop.com`,
-		AS_ENDPOINT: `${protocol}://${cluster}as.good-loop.com`,
-		DEMO_ENDPOINT: `${protocol}://${cluster}demo.good-loop.com`,
-		DATALOG_ENDPOINT: `${protocol}://${cluster}lg.good-loop.com/data`,
-		MEDIA_ENDPOINT: `${protocol}://${cluster}uploads.good-loop.com`,
-		ANIM_ENDPOINT: `${protocol}://${cluster}portal.good-loop.com/_anim`,
-		CHAT_ENDPOINT: `${protocol}://${cluster}chat.good-loop.com/reply`,
-		// DATALOG_DATASPACE: 'gl',
-		// ENDPOINT_NGO: 'https://test.sogive.org/charity',
-		// JUICE_ENDPOINT: 'https://localjuice.good-loop.com',
-		// ADRECORDER_ENDPOINT: 'http://localadrecorder.good-loop.com/record',
-	}
+// Change to "http" if you don't have SSL set up locally
+const PROTOCOL_LOCAL = 'https';
+const protocol = (cluster === 'local') ? PROTOCOL_LOCAL : 'https';
+
+export const ServerIOOverrides = {
+	APIBASE: `${protocol}://${cluster}portal.good-loop.com`,
+	AS_ENDPOINT: `${protocol}://${cluster}as.good-loop.com`,
+	PORTAL_ENDPOINT: `${protocol}://${cluster}portal.good-loop.com`,
+	DEMO_ENDPOINT: `${protocol}://${cluster}demo.good-loop.com`,
+	DATALOG_ENDPOINT: `${protocol}://${cluster}lg.good-loop.com/data`,
+	MEDIA_ENDPOINT: `${protocol}://${cluster}uploads.good-loop.com`,
+	ANIM_ENDPOINT: `${protocol}://${cluster}portal.good-loop.com/_anim`,
+	CHAT_ENDPOINT: `${protocol}://${cluster}chat.good-loop.com/reply`,
+	MEASURE_ENDPOINT: `${protocol}://localmeasure.good-loop.com/measure`,
+	// DATALOG_DATASPACE: 'gl',
+	// ENDPOINT_NGO: 'https://test.sogive.org/charity',
+	// JUICE_ENDPOINT: 'https://localjuice.good-loop.com',
+	// ADRECORDER_ENDPOINT: 'http://localadrecorder.good-loop.com/record',
 };

--- a/template/webpack.config.js
+++ b/template/webpack.config.js
@@ -10,19 +10,24 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 // Needed to check hostname & try to load local config file
 const os = require('os');
 const fs = require('fs');
-// Needed IF you want to run git commands & get current branch
+// Uncomment if this project needs to run git commands - e.g. to get current branch
 // const { execSync } = require('child_process');
+
 
 const webDir = process.env.OUTPUT_WEB_DIR || 'web';
 
-// Check for file "config/$HOSTNAME.js" and look for ServerIO overrides in it
-let SERVERIO_OVERRIDES = JSON.stringify({});
-const configFile = './config/' + os.hostname() + '.js';
-if (fs.existsSync(configFile)) {
-	/* eslint-disable-next-line global-require, import/no-dynamic-require */
-	let hostConfig = require(configFile);
-	if (hostConfig.ServerIOOverrides) SERVERIO_OVERRIDES = JSON.stringify(hostConfig.ServerIOOverrides);
+
+// Check for file "config/$HOSTNAME.js" so it can be require()d wherever needed to pull in host-specific overrides
+let CONFIG_FILE = './config/' + os.hostname() + '.js';
+if (fs.existsSync(CONFIG_FILE)) {
+	console.log('Using host-specific config file:', CONFIG_FILE);
+	CONFIG_FILE = CONFIG_FILE.replace(/^\./, ''); // strip initial . and treat as project-absolute path
+} else {
+	console.log('No host-specific config file found, using defaults.');
+	CONFIG_FILE = null;
 }
+CONFIG_FILE = JSON.stringify(CONFIG_FILE);
+
 
 const baseConfig = {
 	// NB When editing keep the "our code" entry point last in this list - makeConfig override depends on this position.
@@ -92,7 +97,7 @@ const baseConfig = {
 	plugins: [
 		new MiniCssExtractPlugin({ filename: 'style/main.css' }),
 		new webpack.DefinePlugin({
-			'process.env': { SERVERIO_OVERRIDES },
+			'process.env': { CONFIG_FILE },
 		}),
 	]
 };


### PR DESCRIPTION
Old way: read overrides from host-specific config file `$hostname.js` (if it exists) when executing webpack.config.js; jam them into process.env as an object literal.
Drawbacks: Config file is only read once, so webpack must be restarted for edits to take effect; have to make further changes to webpack.config.js if we want to add other types of override.

New way: Check for a host-specific config file `$hostname.js` when executing webpack.config.js and insert its path in process.env; ServerIOBase loads the file with `require()` if it exists and pulls the overrides from its exports.
Expanding the config file to stuff other than endpoint overrides is just a matter of $hostname.js exporting another object and `require()`ing it where it's needed.

Edits made to template webpack.config.js and example override file to show new format.