### PR TITLE
DevOnly component: custom tags/components, also allow testers

### DIFF
--- a/base/components/DevOnly.jsx
+++ b/base/components/DevOnly.jsx
@@ -1,14 +1,21 @@
-import React, { useState } from 'react';
+import React from 'react';
 import Roles from '../Roles';
+import { space } from '../utils/miscutils';
+
 
 /**
- * Only show the contents to GL developers.
- * 
+ * Only show the contents to GL developers (or testers, if "test" flag set).
  * See also TODO. Use TODO for work-in-progress, and DevOnly for long-term dev-only content.
+ * @param {Object} p
+ * @param {boolean} [p.bare] Set to omit wrapper element and just return children.
+ * @param {boolean} [p.test] Set to allow tester users (less access than dev) to see contents.
+ * @param {String|Function} [p.Tag] Default is <div> but can be any tagname or JSX component which accepts children
+ * @param {String} [p.className] Concatenated with default class ".dev-only" on wrapper element
  */
-function DevOnly({children}) {
-	if (!Roles.isDev()) return null;
-	return <div className="dev-only">{children}</div>;
+function DevOnly({bare, test, Tag = 'div', className, children, ...props}) {
+	if (!Roles.isDev() && !(test && Roles.isTester())) return null;
+	if (bare) return children;
+	return <Tag className={space('dev-only', className)} {...props}>{children}</Tag>;
 }
 
 export default DevOnly;


### PR DESCRIPTION
- Pass a component or tagname in the `Tag` prop to use it instead of `<div>`
- Set the `test` prop to show/hide on `Roles.isTester()` instead of `isDev()`
- Pass other supplied props