### PR TITLE
PropControlDataItem remove <Form> and fix overflow

### DIFF
--- a/base/components/propcontrols/PropControlDataItem.jsx
+++ b/base/components/propcontrols/PropControlDataItem.jsx
@@ -1,10 +1,10 @@
 
 import React, { useEffect, useState } from 'react';
-import { Input, Button, ButtonGroup, Form } from 'reactstrap';
+import { Input, Button, ButtonGroup, FormGroup } from 'reactstrap';
 
-import ListLoad, {CreateButton} from '../ListLoad';
+import ListLoad, { CreateButton } from '../ListLoad';
 
-import PropControl, {  PropControlParams, registerControl } from '../PropControl';
+import PropControl, { PropControlParams, registerControl } from '../PropControl';
 import { getDataItem } from '../../plumbing/Crud';
 import { getId } from '../../data/DataClass';
 import { encURI } from '../../utils/miscutils';
@@ -121,7 +121,7 @@ setRawValue, storeValue, modelValueFromInput,
 	const showCreate = !pvDataItem.value && canCreate && rawValue;
 
 	return (
-		<Form inline className="data-item-control" onFocus={onFocus} onBlur={onBlur}>
+		<div className="data-item-control" onFocus={onFocus} onBlur={onBlur}>
 			{showItem ? <>
 				<ButtonGroup>
 					<Button color="secondary" className="preview" tag={notALink ? 'span' : A}
@@ -134,13 +134,13 @@ setRawValue, storeValue, modelValueFromInput,
 				</ButtonGroup>
 				{showId && <div><small>ID: <code>{rawValue || storeValue}</code></small></div>}
 			</> : <>
-				<div className="dropdown-sizer">
+				<FormGroup className="dropdown-sizer">
 					<Input type="text" value={rawValue || storeValue || ''} onChange={onChange} />
 					{rawValue && showLL && <div className="items-dropdown card card-body">
 						<ListLoad hideTotal type={itemType} status={status}
-							domain={domain} 
-							filter={rawValue} 
-							filterFn={item => ! item.redirect /* avoid deprecated redirect objects */}
+							domain={domain}
+							filter={rawValue}
+							filterFn={item => !item.redirect /* avoid deprecated redirect objects */}
 							unwrapped sort={sort}
 							ListItem={SlimListItem}
 							// TODO allow ListLoad to show if there are only a few options
@@ -152,13 +152,13 @@ setRawValue, storeValue, modelValueFromInput,
 							list={list}
 						/>
 					</div>}
-				</div>
-				{showCreate && <CreateButton
-					type={itemType} base={base} id={baseId} className="ml-1"
-					saveFn={saveDraftFnFactory({type, key: prop})} then={({item}) => doSet(item)}
-				/>}
+					{showCreate && <CreateButton
+						type={itemType} base={base} id={baseId} className="ml-1"
+						saveFn={saveDraftFnFactory({type, key: prop})} then={({item}) => doSet(item)}
+					/>}
+				</FormGroup>
 			</>}
-		</Form>
+		</div>
 	);
 }
 

--- a/base/style/PropControl.less
+++ b/base/style/PropControl.less
@@ -254,6 +254,7 @@ span.preview .DataItemBadge {
 .data-item-control {
 	.dropdown-sizer {
 		position: relative; // This is a size/position reference for the floating dropdown list
+		display: flex; // input box and "Create" button (if present) side-by-side
 	}
 
 	// Ellipsize text label if it would overflow
@@ -261,8 +262,8 @@ span.preview .DataItemBadge {
 		overflow: hidden;
 		max-width: 100%;
 	}
-	.btn.clear {
-		flex-shrink: 0; // squash text label but never X button
+	.btn.clear, .btn-create {
+		flex-shrink: 0; // let item badge or text input shrink, but never x/create button
 	}
 	.DataItemBadge {
 		max-width: 100%;
@@ -279,6 +280,7 @@ span.preview .DataItemBadge {
 		min-width: 100%;
 		max-width: 20rem;
 		top: 100%;
+		margin-top: 0.25em; // Small gap between input and dropdown
 		left: 0;
 		z-index: 999; // Place in front of random single-digit z-index Bootstrap elements below
 


### PR DESCRIPTION
As on the tin. Stop React complaining there's a `<form>` in a `<form>`, stop Bootstrap's sizing bursting the PCDI input out of its container.