### PR TITLE
PropControlDataItem fix "embed" prop showing [object Object]

### DIFF
--- a/base/components/propcontrols/PropControlDataItem.jsx
+++ b/base/components/propcontrols/PropControlDataItem.jsx
@@ -1,6 +1,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { Input, Button, ButtonGroup, FormGroup } from 'reactstrap';
+import { cloneDeep } from 'lodash';
 
 import ListLoad, { CreateButton } from '../ListLoad';
 
@@ -31,11 +32,10 @@ function SlimListItem({item, onClick, ...props}) {
  * @param {?String} p.status Defaulst to PUB_OR_DRAFT
  * @param {?String} p.q Optional search query (user input will add to this). Usually unset.
  * @param {?String} p.list Optional list to use (instead of querying the server). Usually unset.
- * @param {?Boolean} p.embed If true, set a copy of the data-item. By default, what gets set is the ID
+ * @param {?Boolean} p.embed If true, set a copy of the data-item. By default, what gets set is the ID.
  */
-function PropControlDataItem2({canCreate, createProp="id", base, path, prop, proppath, rawValue, 
-set, 
-setRawValue, storeValue, modelValueFromInput, 
+function PropControlDataItem2({canCreate, createProp = 'id', base, path, prop, proppath, rawValue,
+	set, setRawValue, storeValue, modelValueFromInput,
 	type, itemType, status=KStatus.PUB_OR_DRAFT, domain, list, q, sort, embed, pageSize=20, navpage, notALink, readOnly, showId=true,
 }) {
 	const [showLL, setShowLL] = useState(); // Show/hide ListLoad
@@ -69,30 +69,18 @@ setRawValue, storeValue, modelValueFromInput,
 		});
 	};
 
-	let pvDataItem = {};
-	if (rawValue || (storeValue && !embed)) {
-		pvDataItem = getDataItem({ type: itemType, id: rawValue || storeValue, status, domain, swallow: true });
-	}
-
-	let onChange = e => {
+	const onChange = e => {
 		let id = e.target.value;
 		setRawValue(id);
 		// signal "user is typing, don't replace search box with item badge, even if this is a valid ID"
 		// NB: This fixes an issue where if "a" was a valid ID then you couldn't enter "apple"
 		setInputClean(false);
-		// Require the user to click to set
-		// // if embed (store whole item, not just ID), only set modelvalue on-click
-		// if (embed) return;
-		// id = id.replace(/ $/g, "");
-		// let mv = modelValueFromInput? modelValueFromInput(id, type, e, storeValue) : id;
-		// set(mv);
-		// DSsetValue(proppath, mv);
 	};
 
 	const doSet = item => {
 		const id = getId(item); // NB: this will be trimmed as it came from an item
 		setRawValue(id);
-		let mv = embed? Object.assign({}, item) : id;
+		let mv = embed ? cloneDeep(item) : id;
 		if (modelValueFromInput) mv = modelValueFromInput(mv, type, {}, storeValue);
 		// DSsetValue(proppath, mv, true);
 		set(mv);
@@ -103,39 +91,49 @@ setRawValue, storeValue, modelValueFromInput,
 	const doClear = () => {
 		setRawValue('');
 		set(null);
-		// DSsetValue(proppath, '');
 	};
+
+	// Do we have a candidate data-item?
+	const itemId = rawValue || (embed ? getId(storeValue) : storeValue);
+	let dataItem = null;
+	if (embed && storeValue) {
+		// data-item is stored whole at path+prop
+		dataItem = storeValue;
+	} else if (itemId) {
+		// attempt to fetch data-item
+		dataItem = getDataItem({ type: itemType, id: itemId, status, domain, swallow: true }).value;
+	}
 
 	// (default create behaviour) the input names the object
 	if (rawValue && createProp) {
 		if (!base) base = {};
 		base[createProp] = rawValue;
 	}
-	let baseId = base && base.id;
+	const baseId = base && base.id;
 	if (baseId) delete base.id; // manage CreateButton's defences
 
 	// If the user has entered something in the search box, and it happens to be a valid ID -
 	// don't replace the search box with the item badge until they select it in the dropdown!
-	const showItem = pvDataItem.value && inputClean;
+	const showItem = dataItem && inputClean;
 	// Offer to create an item with name = current input value
-	const showCreate = !pvDataItem.value && canCreate && rawValue;
+	const showCreate = !dataItem && canCreate && rawValue;
 
 	return (
 		<div className="data-item-control" onFocus={onFocus} onBlur={onBlur}>
 			{showItem ? <>
 				<ButtonGroup>
 					<Button color="secondary" className="preview" tag={notALink ? 'span' : A}
-						href={!notALink ? `/#${(navpage||itemType.toLowerCase())}/${encURI(getId(pvDataItem.value))}` : undefined}
+						href={!notALink ? `/#${(navpage||itemType.toLowerCase())}/${encURI(getId(dataItem))}` : undefined}
 						title={!notALink ? `Switch to editing this ${itemType}` : undefined}
 					>
-						<SlimListItem type={itemType} item={pvDataItem.value} noClick />
+						<SlimListItem type={itemType} item={dataItem} noClick />
 					</Button>
 					{!readOnly && <Button color="secondary" className="clear" onClick={doClear}>🗙</Button>}
 				</ButtonGroup>
-				{showId && <div><small>ID: <code>{rawValue || storeValue}</code></small></div>}
+				{showId && <div><small>ID: <code>{itemId}</code></small></div>}
 			</> : <>
 				<FormGroup className="dropdown-sizer">
-					<Input type="text" value={rawValue || storeValue || ''} onChange={onChange} />
+					<Input type="text" value={itemId} onChange={onChange} />
 					{rawValue && showLL && <div className="items-dropdown card card-body">
 						<ListLoad hideTotal type={itemType} status={status}
 							domain={domain}


### PR DESCRIPTION
It was unused (outside of studio) and had bitrotted at some point - basically some key logic no longer took into account the fact that `storeValue` isn't an ID in embed mode. I needed it working while untangling the AdvertPage charity editor, so I fixed it.