### PR TITLE
Large cleanup of ImpagctPageData.js:getImpressionsByCampaignByCountry + attendant data-class refactors

### DIFF
--- a/base/data/DeprecatedImpactHubData.js
+++ b/base/data/DeprecatedImpactHubData.js
@@ -479,7 +479,7 @@ Campaign.viewcountDeprecated = ({campaign, status}) => {
 	}
 	const pvAllAds = Campaign.pvAdsLegacy({campaign, status});
 	const allAds = List.hits(pvAllAds.value) || [];
-	const viewcount4campaign = Advert.viewcountByCampaign(allAds);
+	const viewcount4campaign = Advert.viewcountByCampaign(allAds).value;
 	if (!viewcount4campaign) return 0;
 	return sum(Object.values(viewcount4campaign));;
 };


### PR DESCRIPTION
As briefly as possible:
- The Impact Overview page was showing weird data for users who were logged in, but didn't have full access to the focus brands/campaigns/whatever.
- This was due to CrudServlets post-filtering results based on share access.
- This could be mostly fixed by adding `access: 'public'` to the call params when fetching campaigns-for-brand and other such chained retrievals.
- A LOT of the fetch convenience functions in DataClass JS files were a very big mess and didn't expose promises or PVs where they should, making it unnecessarily difficult to compose and update them.
- So, big refactor. All those functions now expose the underlying CRUD PromiseValue (or synthesise one through DataStore.fetch), and apply `access: 'public'` to the fetch params.

While I was at it: `ImpactData.js:getImpressionsByCampaignByCountry`, the overgrown function which fetched impression counts for a pile of campaigns and compiled them into a unified country-to-impressions map, was doing some weird things:
- Way too many campaigns were getting assigned to "unset", because the "move these impressions & campaigns to unset" code was just incrementing the number-of-campaigns rather than maintaining a set of campaign IDs for deduping purposes.
  - The code now maintains sets of campaign IDs for deduplication when blocks of impressions are moved to `region: 'unset'`.
- Campaigns were getting questionably assigned to `GB`, because they had large numbers of impressions in "unset" (generally predating geolocation) - and then a few dozen hits in the UK, which would have been us testing.
  - Campaigns with 99% of their hits in "unset" and < 200 hits in the next highest country are now considered `region: 'unset'`, if that next highest country is `GB`.