### PR TITLE
SavePublishDeleteEtc: saveDraftFnFactory to allow numeric keys

### DIFF
--- a/base/components/SavePublishDeleteEtc.jsx
+++ b/base/components/SavePublishDeleteEtc.jsx
@@ -59,7 +59,7 @@ const _saveDraftFn4typeid = {};
 */
 const saveDraftFnFactory = ({type, key}) => {
 	assMatch(type, String);
-	assMatch(key, String);
+	assMatch(key, 'String|Number');
 	const k = type+key;
 	let sdfn = _saveDraftFn4typeid[k];
 	if (!sdfn) {


### PR DESCRIPTION
The PropControlDataItem for setting charities on an advert uses an array index for its prop name - saveDraftFnFactory thinks keys should only be strings.

Possibly other types should be accepted as well, but definitely strings and numerics should.