### PR TITLE
Page analysis / recommendations: set no-cache when loading manifest.json

### DIFF
--- a/base/components/creative-recommendations/recommendation-utils.js
+++ b/base/components/creative-recommendations/recommendation-utils.js
@@ -120,7 +120,9 @@ export function fetchSavedManifest(tag) {
 	return DataStore.fetch(savedManifestPath({tag}), () => {
 		// fetchFn returning null is OK - no tag means stored-manifest-for-tag should resolve null
 		if (!tag) return null;
-		return ServerIO.load(storedManifestForTag(tag), {swallow: true}).then(res => {
+		// Static file fetch, rather than backend resource - we need to specify no caching,
+		// as successive analyses overwrite this JSON file & delete images pertaining to previous versions.
+		return ServerIO.load(storedManifestForTag(tag), {swallow: true, cache: false}).then(res => {
 			res.data.forEach(doubleLinkManifest); // Add parent info for easy frame navigation
 			return res;
 		});


### PR DESCRIPTION
Addresses https://good-loop.monday.com/boards/2603585504/pulses/5583447402.
- Analysis results are stored (with the URL to a screenshot) as a static JSON file.
- When a new analysis is done, all saved files from the previous one are deleted.
- Because the manifests are static files, they don't get the same inherent staleness protection as backend fetches.
- This can cause a bug where a user's browser uses a cached copy of a previously-done analysis, when another user has actually  done a newer analysis in between, and the screenshot file no longer exists.

This PR explicitly instructs the fetching code to avoid the cache.