### PR TITLE
PropControlCode: fix highlighting overlay linebreak sync

### DIFF
--- a/base/components/propcontrols/PropControlCode.jsx
+++ b/base/components/propcontrols/PropControlCode.jsx
@@ -194,7 +194,7 @@ const PropControlCode = ({ lang, onChange, onKeyDown, rawValue }) => {
 				<div className="highlighter" ref={highlightRef}>
 					{tokenLines.map((line, i) => (
 						// The leading <wbr> is a zero-width space that ensures empty lines still occupy height
-						<div key={i}><wbr /><RenderToken token={line} /></div>
+						<div className="line" key={i}><wbr /><RenderToken token={line} /></div>
 					))}
 				</div>
 			</code>

--- a/base/style/PropControls/PropControlCode.less
+++ b/base/style/PropControls/PropControlCode.less
@@ -31,12 +31,16 @@
 		left: 0;
 		width: 100%;
 		height: 100%;
-		mix-blend-mode: multiply;
 		pointer-events: none;
 		background-color: transparent;
-		overflow: hidden;
+		overflow-y: scroll; // Add scrollbar so inner width matches textarea
+		resize: vertical; // Add resize handle so scrollbar height matches textarea
+		.line {
+			mix-blend-mode: multiply;
+		}
 		.token {
 			background-color: currentColor;
+			white-space: break-spaces;
 		}
 	}
 }


### PR DESCRIPTION
Very fussy CSS tweaks to bring the highlighting overlay's linebreaks closer to the textarea.